### PR TITLE
define question as not manual graded, solves #66

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -76,7 +76,7 @@ class qtype_matrix extends question_type {
      * @return boolean true if this question type sometimes requires manual grading.
      */
     public function is_manual_graded(): bool {
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
defines the qtype_matrix question as one that is not manually graded. Other plugins (such as studentquiz) can only import automatically graded questions. qtype_matrix is well suited for automatical grading

see https://github.com/ndunand/moodle-qtype_matrix/issues/66