### PR TITLE
#67 The feedback should be formatted to help the filter proceed

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -97,7 +97,7 @@ class renderer extends qtype_with_combined_feedback_renderer {
             if ($options->correctness) {
                 $rowgrade = $question->grading()->grade_row($question, $row, $response);
                 $feedback = $row->feedback['text'];
-                $feedback = strip_tags($feedback) ? $feedback : '';
+                $feedback = strip_tags($feedback) ? format_text($feedback) : '';
                 $rowdata[] = $this->feedback_image($rowgrade) . $feedback;
             }
             $table->data[] = $rowdata;


### PR DESCRIPTION
In this pull request, the format_text function has been applied to the feedback of each line so that the Moodle filters can process this feedback.