### PR TITLE
Update question.php shuffle_authorized must return a bool always

### DIFF
--- a/question.php
+++ b/question.php
@@ -204,7 +204,8 @@ class qtype_matrix_question extends question_graded_automatically_with_countback
             return true;
         }
 
-        return $DB->get_record('quiz', ['id' => $cm->instance])->shuffleanswers;
+        $quiz = $DB->get_record('quiz', ['id' => $cm->instance]);
+        return $quiz ? (bool)$quiz->shuffleanswers : false;
     }
 
     /**


### PR DESCRIPTION
The get record can return false when false->shuffleanswers is called null is passed as the return value which is not possible as this function needs to return a bool