### PR TITLE
Fix: The default of multiple was false before the cleaner changes. It should be again.

### DIFF
--- a/classes/local/question_cleaner.php
+++ b/classes/local/question_cleaner.php
@@ -12,7 +12,7 @@ use \stdClass;
 
 class question_cleaner {
 
-    const DEFAULT_MULTIPLE = true;
+    const DEFAULT_MULTIPLE = false;
 
     const DEFAULT_SHUFFLEANSWERS = true;
 


### PR DESCRIPTION
Due to some earlier changes, I introduced that the default of multiple was true somehow. Here's the fix to set it back to false.