### PR TITLE
#77 override rebase

### DIFF
--- a/backup/moodle2/backup_qtype_matrix_plugin.class.php
+++ b/backup/moodle2/backup_qtype_matrix_plugin.class.php
@@ -48,7 +48,7 @@ class backup_qtype_matrix_plugin extends backup_qtype_plugin {
         $matrixcol = new backup_nested_element('col', ['id'], ['shorttext', 'description']);
 
         $matrixrows = new backup_nested_element('rows');
-        $matrixrow = new backup_nested_element('row', ['id'], ['shorttext', 'description', 'feedback']);
+        $matrixrow = new backup_nested_element('row', ['id'], ['shorttext', 'description', 'feedback', 'autopass']);
 
         $matrixweights = new backup_nested_element('weights');
         $matrixweight = new backup_nested_element('weight', ['id'], ['rowid', 'colid', 'weight']);

--- a/backup/moodle2/restore_qtype_matrix_plugin.class.php
+++ b/backup/moodle2/restore_qtype_matrix_plugin.class.php
@@ -24,7 +24,6 @@ require_once $CFG->dirroot . '/question/type/matrix/questiontype.php';
 
 use qtype_matrix\db\question_matrix_store;
 use qtype_matrix\db\stepdata_migration_utils;
-use core\exception\moodle_exception;
 
 /**
  * restore plugin class that provides the necessary information
@@ -32,6 +31,11 @@ use core\exception\moodle_exception;
  *
  */
 class restore_qtype_matrix_plugin extends restore_qtype_plugin {
+
+    public const ERROR_INCONSISTENT_BEHAVIOUR = 'error_inconsistent_behaviour_restoring_backup';
+
+    public const ERROR_STEP_DATA_NOT_MIGRATABLE =
+        'error_qtype_matrix_attempt_step_data_not_migratable';
 
     private $attemptorders = [];
 
@@ -52,26 +56,25 @@ class restore_qtype_matrix_plugin extends restore_qtype_plugin {
     /**
      * Process the qtype/matrix
      *
-     * @param $data
+     * @param $matrixbackup
      * @return void
      * @throws dml_exception
      */
-    public function process_matrix($data): void {
+    public function process_matrix($matrixbackup): void {
         global $DB;
-        $data = (object) $data;
-        $oldid = $data->id;
+        $matrixbackup = (object) $matrixbackup;
 
-        if ($this->is_question_created()) {
-            $qtypeobj = question_bank::get_qtype($this->pluginname);
-            $data->{$qtypeobj->questionid_column_name()} = $this->get_new_parentid('question');
-            $extrafields = $qtypeobj->extra_question_fields();
-            $extrafieldstable = array_shift($extrafields);
-            $newitemid = $DB->insert_record($extrafieldstable, $data);
-            $this->set_mapping('matrix', $oldid, $newitemid);
+        if (!$this->is_question_created()) {
+            // Question was mapped, so identical structures exist.
+            return;
         }
-        else {
-            $this->set_mapping('matrix', $oldid, null);
-        }
+        // A question is created if even the slightest difference between the database and backup question exists.
+        // If a question was created and not mapped, all the other Matrix structures will need to be created, too.
+        $qtypeobj = question_bank::get_qtype($this->pluginname);
+        $matrixbackup->{$qtypeobj->questionid_column_name()} = $this->get_new_parentid('question');
+        $matrixtable = $qtypeobj->extra_question_fields()[0];
+        $newmatrixid = $DB->insert_record($matrixtable, $matrixbackup);
+        $this->set_mapping('matrix', $matrixbackup->id, $newmatrixid);
     }
 
     /**
@@ -86,81 +89,98 @@ class restore_qtype_matrix_plugin extends restore_qtype_plugin {
     /**
      * Process the qtype/rows/row element.
      *
-     * @param $data
+     * @param $rowbackup
      * @return void
      * @throws dml_exception
      */
-    public function process_row($data): void {
-        $this->process_dim($data, true);
+    public function process_row($rowbackup): void {
+        $this->process_dim($rowbackup, true);
     }
 
     /**
      * Process the qtype/cols/col element.
      *
-     * @param $data
+     * @param $colbackup
      * @return void
      * @throws dml_exception
      */
-    public function process_col($data): void {
-        $this->process_dim($data, false);
+    public function process_col($colbackup): void {
+        $this->process_dim($colbackup, false);
     }
 
-    private function process_dim($backupdata, bool $isrow): void {
+    private function process_dim($dimbackup, bool $isrow): void {
         global $DB;
-        $backupdata = (object) $backupdata;
-        $oldid = $backupdata->id;
+        $dimbackup = (object) $dimbackup;
 
-        $oldmatrixid = $this->get_old_parentid('matrix');
-        $newmatrixid = $this->get_new_parentid('matrix');
-        if (!$newmatrixid) {
+        if (!$this->is_question_created()) {
+            // Question was mapped, so identical structures exist.
             return;
         }
+        $newmatrixid = $this->get_new_parentid('matrix');
 
-        $dim = $isrow ? 'row' : 'col';
-        $dimtable = $isrow ? 'qtype_matrix_rows' : 'qtype_matrix_cols';
-        $newitemid = 0;
-        if ($this->is_question_created()) {
-            $backupdata->matrixid = $newmatrixid;
-            $newitemid = $DB->insert_record($dimtable, $backupdata);
-        } else {
-            // FIXME: It isn't ensured that 2 rows/cols don't have the same shorttext right now.
-            $originalrecords = $DB->get_records($dimtable, ['matrixid' => $newmatrixid]);
-            foreach ($originalrecords as $record) {
-                if ($backupdata->shorttext == $record->shorttext) {
-                    $newitemid = $record->id;
-                }
+        if (!$newmatrixid) {
+            // This should not happen. Either question and matrix were created or both were mapped.
+            throw new restore_step_exception(self::ERROR_INCONSISTENT_BEHAVIOUR);
+        }
+
+        if ($isrow && $dimbackup->autopass) {
+            // Avoid storing first versions of matrix questions where autopassing is enabled.
+            // Autopassing the first version would make no sense.
+            if ($this->created_as_first_version()) {
+                $dimbackup->autopass = false;
             }
         }
-        if (!$newitemid) {
-            $info = new stdClass();
-            $info->filequestionid = $oldmatrixid;
-            $info->dbquestionid = $newmatrixid;
-            $info->answer = $backupdata->shorttext;
-            throw new restore_step_exception('error_question_answers_missing_in_db', $info);
-        } else {
-            $this->set_mapping($dim, $oldid, $newitemid);
-        }
+        // At this point we know that matrix dimensions must be created using the backup.
+        $dimbackup->matrixid = $newmatrixid;
+
+        $dimtable = $isrow ? 'qtype_matrix_rows' : 'qtype_matrix_cols';
+        $newdimid = $DB->insert_record($dimtable, $dimbackup);
+
+        $dim = $isrow ? 'row' : 'col';
+        $this->set_mapping($dim, $dimbackup->id, $newdimid);
     }
 
+    public function created_as_first_version():bool {
+        global $DB;
+        $newquestionversionid = $this->get_new_parentid('question_versions');
+        if (!$newquestionversionid) {
+            // This should never happen here.
+            throw new restore_step_exception(self::ERROR_INCONSISTENT_BEHAVIOUR);
+        }
+        $params = [
+            'id' => $newquestionversionid
+        ];
+        $newquestionversion = (int) $DB->get_field('question_versions', 'version', $params);
+        return !($newquestionversion > 1);
+    }
     /**
      * Process the qtype/weights/weight element
      *
-     * @param $data
+     * @param $weightbackup
      * @return void
      * @throws dml_exception
      */
-    public function process_weight($data): void {
+    public function process_weight($weightbackup): void {
         global $DB;
-        $data = (object) $data;
-        $oldid = $data->id;
+        $weightbackup = (object) $weightbackup;
 
-        $key = $data->colid . 'x' . $data->rowid;
-        $data->colid = $this->get_mappingid('col', $data->colid);
-        $data->rowid = $this->get_mappingid('row', $data->rowid);
+        if (!$this->is_question_created()) {
+            // Question was mapped, so identical structures exist.
+            return;
+        }
+
+        $weightmapid = $weightbackup->colid . 'x' . $weightbackup->rowid;
+        $weightbackup->colid = $this->get_mappingid('col', $weightbackup->colid);
+        $weightbackup->rowid = $this->get_mappingid('row', $weightbackup->rowid);
+
+        if (!$weightbackup->colid || !$weightbackup->rowid) {
+            // This should not happen. If a question was created, so would be the dimension records.
+            throw new restore_step_exception(self::ERROR_INCONSISTENT_BEHAVIOUR);
+        }
         // This prevents bad data to arrive in the database. Currently the only useful weight values are 1 or 0.
-        $data->weight = (int) (bool) $data->weight;
-        $newitemid = $DB->insert_record('qtype_matrix_weights', $data);
-        $this->set_mapping('weight' . $key, $oldid, $newitemid);
+        $weightbackup->weight = (int) (bool) $weightbackup->weight;
+        $newweightid = $DB->insert_record('qtype_matrix_weights', $weightbackup);
+        $this->set_mapping('weight' . $weightmapid, $weightbackup->id, $newweightid);
     }
 
     /**
@@ -200,20 +220,22 @@ class restore_qtype_matrix_plugin extends restore_qtype_plugin {
 
     public function recode_response($questionid, $sequencenumber, array $response): array {
         $recodedresponse = [];
+        // We wouldn't need to recode a response if there hadn't been matrix structures created.
         $newattemptid = $this->get_new_parentid('question_attempt');
 
         if ($sequencenumber == 0) {
+            // For a restore to be possible, it's vital that the row order is extractable.
             if (isset($response[qtype_matrix_question::KEY_ROWS_ORDER])) {
                 $recodedresponse[qtype_matrix_question::KEY_ROWS_ORDER] =
                     $this->recode_choice_order($response[qtype_matrix_question::KEY_ROWS_ORDER]);
                 $this->attemptorders[$newattemptid] = explode(',', $recodedresponse[qtype_matrix_question::KEY_ROWS_ORDER]);
             } else {
-                throw new restore_step_exception('error_qtype_matrix_attempt_step_data_not_migratable');
+                throw new restore_step_exception(self::ERROR_STEP_DATA_NOT_MIGRATABLE);
             }
         } else {
             $neworder = $this->attemptorders[$newattemptid] ?? [];
             if (!$neworder) {
-                throw new restore_step_exception('error_qtype_matrix_attempt_step_data_not_migratable');
+                throw new restore_step_exception(self::ERROR_STEP_DATA_NOT_MIGRATABLE);
             }
             $store = $this->get_matrix_store();
             $restoredmatrix = $store->get_matrix_by_question_id($questionid);
@@ -221,20 +243,26 @@ class restore_qtype_matrix_plugin extends restore_qtype_plugin {
             $restoredcolids = array_keys($restoredcols);
             foreach ($response as $key => $value) {
                 if (str_contains($key, 'cell')) {
+                    // The attempt still uses the old style stepdata syntax, i.e. absolute database IDs.
+                    // We need to try to fix that, or else the attempt is unusable.
+                    // So we need to go old ID -> new ID -> index in the order of dimensions.
                     $oldrowid = stepdata_migration_utils::extract_row_id($key);
                     $newrowid = $this->get_mappingid('row', $oldrowid, 0);
                     $newrowindex = array_search($newrowid, $neworder);
                     $oldcolid = stepdata_migration_utils::extract_col_id($key, $value);
                     $newcolid = $this->get_mappingid('col', $oldcolid, 0);
                     $newcolindex = array_search($newcolid, $restoredcolids);
-                    // Either we can map a backup ID to new rows/cols of a new question or to an already existing question.
-                    // If we couldn't, then the row/col IDs from the attempt point to those of another earlier question version
+                    // Either we can map a backup dimension ID to new dimension IDs of a new question
+                    // or to an already existing question.
+                    // If we can't, then the absolute dimension IDs in the attempt's order data
+                    // point to those of another earlier question version.
                     // This version may or may not be in the backup and thus may or may not have been restored yet.
                     if ($newrowindex === false || $newcolindex === false) {
-                        throw new restore_step_exception('error_qtype_matrix_attempt_step_data_not_migratable');
+                        throw new restore_step_exception(self::ERROR_STEP_DATA_NOT_MIGRATABLE);
                     }
-                    $newname = qtype_matrix_question::responsekey($newrowindex, $newcolindex);
-                    $recodedresponse[$newname] = true;
+                    // Finally we switch to saying "The Xth row and Yth column is checked in this step".
+                    $newresponsepartname = qtype_matrix_question::responsekey($newrowindex, $newcolindex);
+                    $recodedresponse[$newresponsepartname] = true;
                 } else {
                     $recodedresponse[$key] = $value;
                 }
@@ -294,8 +322,7 @@ class restore_qtype_matrix_plugin extends restore_qtype_plugin {
      */
     public static function convert_backup_to_questiondata(array $backupdata): stdClass {
         $questiondata = parent::convert_backup_to_questiondata($backupdata);
-        $questiondata = qtype_matrix::clean_data($questiondata, true);
-        // Add the matrix-specific options.
+        // Add the matrix-specific options ($questiondata->options already exists).
         if (isset($backupdata['plugin_qtype_matrix_question']['matrix'][0])) {
             $matrix = &$backupdata['plugin_qtype_matrix_question']['matrix'][0];
 
@@ -363,7 +390,7 @@ class restore_qtype_matrix_plugin extends restore_qtype_plugin {
             }
             $questiondata->options->weights = $weights;
         }
-
+        $questiondata = qtype_matrix::clean_data($questiondata, true);
         return $questiondata;
     }
 

--- a/classes/local/grading/all.php
+++ b/classes/local/grading/all.php
@@ -20,6 +20,7 @@ use coding_exception;
 use qtype_matrix\local\interfaces\grading;
 use qtype_matrix\local\lang;
 use qtype_matrix\local\qtype_matrix_grading;
+use qtype_matrix\local\setting;
 use qtype_matrix_question;
 
 /**
@@ -86,13 +87,18 @@ class all extends qtype_matrix_grading implements grading {
      */
     public function grade_row(qtype_matrix_question $question, int $rowindex, array $response):float {
         // All of a row must be correct to get a point.
+        $passgrade = 1.0;
+        $failgrade = 0.0;
+        if ($question->autopass_row($rowindex)) {
+            return $passgrade;
+        }
         foreach (array_keys($question->cols) as $colindex => $colid) {
             $cellanswer = $question->answer($rowindex, $colindex);
             $cellresponse = $question->response($response, $rowindex, $colindex);
             if ($cellanswer != $cellresponse) {
-                return 0.0;
+                return $failgrade;
             }
         }
-        return 1.0;
+        return $passgrade;
     }
 }

--- a/classes/local/grading/difference.php
+++ b/classes/local/grading/difference.php
@@ -71,6 +71,11 @@ class difference extends qtype_matrix_grading implements grading {
      * @return float                            The row grade, either 0 or 1
      */
     public function grade_row(qtype_matrix_question $question, int $rowindex, array $response): float {
+        $failgrade = 0.0;
+        $passgrade = 1.0;
+        if ($question->autopass_row($rowindex)) {
+            return $passgrade;
+        }
         $ansid = 1;
         $respid = 1;
         $ansbool = false;
@@ -91,7 +96,7 @@ class difference extends qtype_matrix_grading implements grading {
             }
         }
         if (!$resbool) {
-            return 0.0;
+            return $failgrade;
         }
         $badleft = $ansid - 1;
         $badright = count($question->cols) - $ansid;

--- a/classes/local/grading/kany.php
+++ b/classes/local/grading/kany.php
@@ -82,6 +82,11 @@ class kany extends qtype_matrix_grading implements grading {
      * @return float                            The row grade, either 0 or 1
      */
     public function grade_row(qtype_matrix_question $question, int $rowindex, array $response): float {
+        $passgrade = 1.0;
+        $failgrade = 0.0;
+        if ($question->autopass_row($rowindex)) {
+            return $passgrade;
+        }
         $onecorrectanswer = false;
         foreach (array_keys($question->cols) as $colindex => $colid) {
             $cellanswer = $question->answer($rowindex, $colindex);
@@ -93,6 +98,6 @@ class kany extends qtype_matrix_grading implements grading {
                 $onecorrectanswer = true;
             }
         }
-        return ($onecorrectanswer) ? 1.0 : 0.0;
+        return ($onecorrectanswer) ? $passgrade : $failgrade;
     }
 }

--- a/classes/local/grading/kprime.php
+++ b/classes/local/grading/kprime.php
@@ -81,14 +81,19 @@ class kprime extends qtype_matrix_grading implements grading {
      * @return float                            The row grade, either 0 or 1
      */
     public function grade_row(qtype_matrix_question $question, int $rowindex, array $response): float {
+        $passgrade = 1.0;
+        $failgrade = 0.0;
+        if ($question->autopass_row($rowindex)) {
+            return $passgrade;
+        }
         foreach (array_keys($question->cols) as $colindex => $colid) {
             $cellanswer = $question->answer($rowindex, $colindex);
             $cellresponse = $question->response($response, $rowindex, $colindex);
             if ($cellanswer != $cellresponse) {
-                return 0.0;
+                return $failgrade;
             }
         }
-        return 1.0;
+        return $passgrade;
     }
 
 }

--- a/classes/local/lang.php
+++ b/classes/local/lang.php
@@ -103,6 +103,14 @@ class lang {
      * @return string
      * @throws coding_exception
      */
+    public static function editform_columnheader_autopass(): string {
+        return self::get('editform_colheader_autopass');
+    }
+
+    /**
+     * @return string
+     * @throws coding_exception
+     */
     public static function true_(): string {
         return self::get('true');
     }

--- a/classes/local/setting.php
+++ b/classes/local/setting.php
@@ -39,6 +39,14 @@ class setting {
     }
 
     /**
+     * @return bool
+     * @throws dml_exception
+     */
+    public static function allow_autopass(): bool {
+        return self::get('allow_autopass');
+    }
+
+    /**
      * Not sure how to type this -> should this be used outside to? did not found any class extern calls?
      *
      * @param string $name

--- a/classes/local/setting.php
+++ b/classes/local/setting.php
@@ -23,6 +23,8 @@ use dml_exception;
 class setting {
     const COMPONENT = 'qtype_matrix';
 
+    const SETTING_ALLOW_AUTOPASS = 'allow_autopass';
+
     public static function show_kprime_gui(): bool {
         global $CFG;
 
@@ -36,6 +38,14 @@ class setting {
      */
     public static function allow_dnd_ui(): bool {
         return self::get('allow_dnd_ui');
+    }
+
+    /**
+     * @return bool
+     * @throws dml_exception
+     */
+    public static function allow_autopass(): bool {
+        return self::get(self::SETTING_ALLOW_AUTOPASS);
     }
 
     /**

--- a/classes/output/formulation_and_controls.php
+++ b/classes/output/formulation_and_controls.php
@@ -36,6 +36,7 @@ class formulation_and_controls implements renderable, templatable {
         $context['isreadonly'] = $this->options->readonly;
         $context['usedndui'] = (setting::allow_dnd_ui() && $question->usedndui);
         $context['showfeedback'] = $showfeedback;
+        $context['hasautopassrows'] = $question->has_autopass_rows();
         // FIXME: I think this (expiredquestion) is no longer possible in Moodle
         // TODO: this is somehow possible since a preview is not a real attempt and therefore it can update the
         // question and it will take away the rows and this will trigger an error her so we skip these.
@@ -58,6 +59,17 @@ class formulation_and_controls implements renderable, templatable {
             $rowcontext = [];
             $row = $question->rows[$rowid];
             $rowcontext['header'] = $this->headercontext($row);
+            $rowcssclasses = [];
+            if ($showfeedback && $question->autopass_row($rowindex)) {
+                $rowcssclasses[] = 'autopassrow';
+                $rowcontext['autopassrow'] = true;
+            }
+            if ($rowindex == ($nrrows - 1)) {
+                $rowcssclasses[] = 'lastrow';
+            }
+            if ($rowcssclasses) {
+                $rowcontext['rowcssclasses'] = implode(' ', $rowcssclasses);
+            }
             $rowcontext['cells'] = [];
             $colindex = 0;
             foreach ($question->cols as $colid => $col) {
@@ -96,9 +108,6 @@ class formulation_and_controls implements renderable, templatable {
                 $feedback = $row->feedback['text'];
                 $feedback = strip_tags($feedback) ? format_text($feedback) : '';
                 $rowcontext['feedback'] = $output->feedback_image($rowgrade) . $feedback;
-            }
-            if ($rowindex == ($nrrows - 1)) {
-                $rowcontext['lastrow'] = true;
             }
             $context['rows'][] = $rowcontext;
         }

--- a/classes/output/formulation_and_controls.php
+++ b/classes/output/formulation_and_controls.php
@@ -36,6 +36,7 @@ class formulation_and_controls implements renderable, templatable {
         $context['isreadonly'] = $this->options->readonly;
         $context['usedndui'] = (setting::allow_dnd_ui() && $question->usedndui);
         $context['showfeedback'] = $showfeedback;
+        $context['hasautopassrows'] = $question->has_autopass_rows();
         // FIXME: I think this (expiredquestion) is no longer possible in Moodle
         // TODO: this is somehow possible since a preview is not a real attempt and therefore it can update the
         // question and it will take away the rows and this will trigger an error her so we skip these.
@@ -58,6 +59,18 @@ class formulation_and_controls implements renderable, templatable {
             $rowcontext = [];
             $row = $question->rows[$rowid];
             $rowcontext['header'] = $this->headercontext($row);
+            $rowcssclasses = [];
+            $displayautopass = $showfeedback && $question->autopass_row($rowindex);
+            $rowcontext['autopassrow'] = $displayautopass;
+            if ($displayautopass) {
+                $rowcssclasses[] = 'autopassrow';
+            }
+            if ($rowindex == ($nrrows - 1)) {
+                $rowcssclasses[] = 'lastrow';
+            }
+            if ($rowcssclasses) {
+                $rowcontext['rowcssclasses'] = implode(' ', $rowcssclasses);
+            }
             $rowcontext['cells'] = [];
             $colindex = 0;
             foreach ($question->cols as $colid => $col) {
@@ -96,9 +109,6 @@ class formulation_and_controls implements renderable, templatable {
                 $feedback = $row->feedback['text'];
                 $feedback = strip_tags($feedback) ? format_text($feedback) : '';
                 $rowcontext['feedback'] = $output->feedback_image($rowgrade) . $feedback;
-            }
-            if ($rowindex == ($nrrows - 1)) {
-                $rowcontext['lastrow'] = true;
             }
             $context['rows'][] = $rowcontext;
         }

--- a/db/install.xml
+++ b/db/install.xml
@@ -52,6 +52,8 @@
                        COMMENT="longer text to explain shorttext."/>
                 <FIELD NAME="feedback" TYPE="text" LENGTH="big" NOTNULL="false" SEQUENCE="false"
                        COMMENT="feedback."/>
+                <FIELD NAME="autopass" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="0"
+                       SEQUENCE="false" COMMENT="Automatically give point when grading the row"/>
             </FIELDS>
             <KEYS>
                 <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,90 +1,80 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PATH="question/type/matrix/db" VERSION="20090313"
+<XMLDB xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PATH="question/type/matrix/db" VERSION="20260114"
        COMMENT="XMLDB file for Moodle question/type/matrix"
        xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
     <TABLES>
-        <TABLE NAME="qtype_matrix" COMMENT="Contains info about matrix questions" NEXT="qtype_matrix_cols">
+        <TABLE NAME="qtype_matrix" COMMENT="Contains info about matrix questions">
             <FIELDS>
-                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true"
-                       NEXT="questionid"/>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true"/>
                 <FIELD NAME="questionid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false"
-                       COMMENT="FK to question table" PREVIOUS="id" NEXT="grademethod"/>
+                       COMMENT="FK to question table"/>
                 <FIELD NAME="grademethod" TYPE="text" LENGTH="small" NOTNULL="true" SEQUENCE="false"
-                       COMMENT="what the grading method is for this question.  Should match a constant in phpcode, QTYPE_MATRIX_GRADING_*"
-                       PREVIOUS="questionid" NEXT="multiple"/>
-                <FIELD NAME="multiple" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="1" SEQUENCE="false"
-                       COMMENT="whether this question is allowed multiple choice (eg checkboxes rather than radio buttons)"
-                       PREVIOUS="grademethod" NEXT="usedndui"/>
-                <FIELD NAME="usedndui" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="0"
-                       SEQUENCE="false" COMMENT="Use drag and drop UI?" PREVIOUS="multiple" NEXT="shuffleanswers"/>
-                <FIELD NAME="shuffleanswers" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="1"
-                       SEQUENCE="false" COMMENT="Shuffle answer statements?" PREVIOUS="usedndui"
+                       COMMENT="Grading method for this question. Should match a constant in phpcode, QTYPE_MATRIX_GRADING_*"
                        />
+                <FIELD NAME="multiple" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="1" SEQUENCE="false"
+                       COMMENT="Whether this question is multiple choice (i.e. checkboxes rather than radio buttons)"/>
+                <FIELD NAME="usedndui" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="0"
+                       SEQUENCE="false" COMMENT="Use drag and drop UI?"/>
+                <FIELD NAME="shuffleanswers" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="1"
+                       SEQUENCE="false" COMMENT="Shuffle answer statements?"/>
             </FIELDS>
             <KEYS>
-                <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="questionidfk"/>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
                 <KEY NAME="questionidfk" TYPE="foreign-unique" FIELDS="questionid" REFTABLE="question" REFFIELDS="id"
-                     COMMENT="fk to question table" PREVIOUS="primary"/>
+                     COMMENT="fk to question table"/>
             </KEYS>
         </TABLE>
-        <TABLE NAME="qtype_matrix_cols" COMMENT="Column definitions for the question matrix"
-               PREVIOUS="qtype_matrix" NEXT="qtype_matrix_rows">
+        <TABLE NAME="qtype_matrix_cols" COMMENT="Column definitions for the question matrix">
             <FIELDS>
-                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true"
-                       NEXT="matrixid"/>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true"/>
                 <FIELD NAME="matrixid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false"
-                       COMMENT="fk to qtype_matrix table" PREVIOUS="id" NEXT="shorttext"/>
+                       COMMENT="fk to qtype_matrix table"/>
                 <FIELD NAME="shorttext" TYPE="text" LENGTH="small" NOTNULL="true" SEQUENCE="false"
-                       COMMENT="short word to fit in the matrix" PREVIOUS="matrixid" NEXT="description"/>
+                       COMMENT="short word to fit in the matrix"/>
                 <FIELD NAME="description" TYPE="text" LENGTH="big" NOTNULL="false" SEQUENCE="false"
-                       COMMENT="longer text to explain shorttext." PREVIOUS="shorttext"/>
+                       COMMENT="longer text to explain shorttext."/>
             </FIELDS>
             <KEYS>
-                <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="matrixidfk"/>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
                 <KEY NAME="matrixidfk" TYPE="foreign" FIELDS="matrixid" REFTABLE="qtype_matrix" REFFIELDS="id"
-                     COMMENT="fk to qtype_matrix table." PREVIOUS="primary"/>
+                     COMMENT="fk to qtype_matrix table."/>
             </KEYS>
         </TABLE>
-        <TABLE NAME="qtype_matrix_rows" COMMENT="Row definitions for the question matrix"
-               PREVIOUS="qtype_matrix_cols" NEXT="qtype_matrix_weights">
+        <TABLE NAME="qtype_matrix_rows" COMMENT="Row definitions for the question matrix">
             <FIELDS>
-                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true"
-                       NEXT="matrixid"/>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true"/>
                 <FIELD NAME="matrixid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false"
-                       COMMENT="fk to qtype_matrix table" PREVIOUS="id" NEXT="shorttext"/>
+                       COMMENT="fk to qtype_matrix table"/>
                 <FIELD NAME="shorttext" TYPE="text" LENGTH="small" NOTNULL="true" SEQUENCE="false"
-                       COMMENT="short word to fit in the matrix" PREVIOUS="matrixid" NEXT="description"/>
+                       COMMENT="short word to fit in the matrix"/>
                 <FIELD NAME="description" TYPE="text" LENGTH="big" NOTNULL="false" SEQUENCE="false"
-                       COMMENT="longer text to explain shorttext." PREVIOUS="shorttext" NEXT="feedback"/>
+                       COMMENT="longer text to explain shorttext."/>
                 <FIELD NAME="feedback" TYPE="text" LENGTH="big" NOTNULL="false" SEQUENCE="false"
-                       COMMENT="feedback." PREVIOUS="description"/>
+                       COMMENT="feedback."/>
             </FIELDS>
             <KEYS>
-                <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="matrixidfk"/>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
                 <KEY NAME="matrixidfk" TYPE="foreign" FIELDS="matrixid" REFTABLE="qtype_matrix" REFFIELDS="id"
-                     COMMENT="fk to qtype_matrix table." PREVIOUS="primary"/>
+                     COMMENT="fk to qtype_matrix table."/>
             </KEYS>
         </TABLE>
-        <TABLE NAME="qtype_matrix_weights" COMMENT="weightings for the cells if necessary."
-               PREVIOUS="qtype_matrix_rows">
+        <TABLE NAME="qtype_matrix_weights" COMMENT="weightings for the cells if necessary.">
             <FIELDS>
-                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true"
-                       NEXT="rowid"/>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true"/>
                 <FIELD NAME="rowid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false"
-                       COMMENT="fk to qtype_matrix_rows" PREVIOUS="id" NEXT="colid"/>
+                       COMMENT="fk to qtype_matrix_rows"/>
                 <FIELD NAME="colid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false"
-                       COMMENT="fk to qtype_matrix_cols" PREVIOUS="rowid" NEXT="weight"/>
+                       COMMENT="fk to qtype_matrix_cols"/>
                 <FIELD NAME="weight" TYPE="float" LENGTH="4" NOTNULL="true" UNSIGNED="false" DEFAULT="0"
-                       SEQUENCE="false" DECIMALS="3" COMMENT="percentage weighting for this cell."
-                       PREVIOUS="colid"/>
+                       SEQUENCE="false" DECIMALS="3" COMMENT="percentage weighting for this cell."/>
             </FIELDS>
             <KEYS>
-                <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="rowidfk"/>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
                 <KEY NAME="rowidfk" TYPE="foreign" FIELDS="rowid" REFTABLE="qtype_matrix_rows" REFFIELDS="id"
-                     COMMENT="fk to qtype_matrix_rows" PREVIOUS="primary" NEXT="colidfk"/>
+                     COMMENT="fk to qtype_matrix_rows"/>
                 <KEY NAME="colidfk" TYPE="foreign" FIELDS="colid" REFTABLE="qtype_matrix_cols" REFFIELDS="id"
-                     COMMENT="fk to qtype_matrix_cols" PREVIOUS="rowidfk"/>
+                     COMMENT="fk to qtype_matrix_cols"/>
             </KEYS>
         </TABLE>
     </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -182,5 +182,21 @@ function xmldb_qtype_matrix_upgrade(int $oldversion): bool {
         $transaction->allow_commit();
         upgrade_plugin_savepoint(true, $stepdatamigrationversion, 'qtype', 'matrix');
     }
+    if ($oldversion < 2025093005) {
+        // Add the override possibility for grading rows.
+        $table = new xmldb_table('qtype_matrix_rows');
+        // Adding fields to table matrix.
+        $autopassfield = $table->add_field(
+            'autopass',
+            XMLDB_TYPE_INTEGER,
+            '2',
+            null,
+            XMLDB_NOTNULL,
+            null,
+            (int) qtype_matrix::DEFAULT_ROW_AUTOPASS
+        );
+        $dbman->add_field($table, $autopassfield);
+        upgrade_plugin_savepoint(true, 2025093005, 'qtype', 'matrix');
+    }
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -184,5 +184,21 @@ function xmldb_qtype_matrix_upgrade(int $oldversion): bool {
         $transaction->allow_commit();
         upgrade_plugin_savepoint(true, $stepdatamigrationversion, 'qtype', 'matrix');
     }
+    if ($oldversion < 2025093005) {
+        // Add the possibility to automatically pass grading for selected rows.
+        $table = new xmldb_table('qtype_matrix_rows');
+        // Adding fields to table matrix.
+        $autopassfield = $table->add_field(
+            'autopass',
+            XMLDB_TYPE_INTEGER,
+            '2',
+            null,
+            XMLDB_NOTNULL,
+            null,
+            (int) qtype_matrix::DEFAULT_ROW_AUTOPASS
+        );
+        $dbman->add_field($table, $autopassfield);
+        upgrade_plugin_savepoint(true, 2025093005, 'qtype', 'matrix');
+    }
     return true;
 }

--- a/edit_matrix_form.php
+++ b/edit_matrix_form.php
@@ -180,6 +180,11 @@ class qtype_matrix_edit_form extends question_edit_form {
         $matrix[] = $builder->create_static(lang::row_feedback());
         $matrix[] = $builder->create_static('</th>');
 
+        if ($this->display_autopass_ui()) {
+            $matrix[] = $builder->create_static('<th>');
+            $matrix[] = $builder->create_static(lang::editform_columnheader_autopass());
+            $matrix[] = $builder->create_static('</th>');
+        }
         $matrix[] = $builder->create_static('<th>');
         if (setting::show_kprime_gui()) {
             $matrix[] = $builder->create_submit(self::PARAM_ADD_COLUMNS, '+', [
@@ -224,9 +229,21 @@ class qtype_matrix_edit_form extends question_edit_form {
 
             $matrix[] = $builder->create_static('</td>');
 
+            $autopassrowinputname = "rows_autopass[$rowindex]";
+            if ($this->display_autopass_ui()) {
+                $matrix[] = $builder->create_static('<td>');
+                $matrix[] = $this->_form->createElement('checkbox', $autopassrowinputname, '');
+                $matrix[] = $builder->create_static('</td>');
+            }
+
+            // Empty cell for the implicit column below the "add column" button
             $matrix[] = $builder->create_static('<td></td>');
 
             $matrix[] = $builder->create_static('</tr>');
+            // Always provide a value for the row autopass, even if we don't or can't use it.
+            if (!$this->display_autopass_ui()) {
+                $this->_form->addElement('hidden', $autopassrowinputname, '0');
+            }
         }
 
         $matrix[] = $builder->create_static('<tr>');
@@ -348,6 +365,17 @@ class qtype_matrix_edit_form extends question_edit_form {
     }
 
     /**
+     * Only display the autopass UI for already saved questions
+     * (i.e. questions where we would save a second version).
+     * Automatically passing the first version would not be sensible.
+     * @return bool
+     * @throws dml_exception
+     */
+    private function display_autopass_ui():bool {
+        return setting::allow_autopass() && (!empty($this->question->id)) && (!$this->question->beingcopied);
+    }
+
+    /**
      *
      * @param $question object
      * @return void
@@ -359,11 +387,15 @@ class qtype_matrix_edit_form extends question_edit_form {
             $question->rows_shorttext = [];
             $question->rows_description = [];
             $question->rows_feedback = [];
+            $question->rows_autopass = [];
 
             foreach ($options->rows as $row) {
                 $question->rows_shorttext[] = $row->shorttext;
                 $question->rows_description[] = $row->description;
                 $question->rows_feedback[] = $row->feedback;
+                if (!$question->beingcopied) {
+                    $question->rows_autopass[] = $row->autopass;
+                }
             }
 
             $question->cols_shorttext = [];

--- a/lang/en/qtype_matrix.php
+++ b/lang/en/qtype_matrix.php
@@ -95,6 +95,7 @@ $string['allow_autopass_desc'] = 'Sometimes you identify badly worded questions/
 // Question display
 $string['cellarialabel'] = 'Select possible answer {$a->answershorttext} for item {$a->itemshorttext}';
 $string['correctresponse'] = 'Correct Response';
+$string['autopassingrow'] = 'Everyone receives full points for this row';
 
 // Regrading
 $string['regrade_different_nr_rows'] = 'Cannot regrade because question versions have different number of rows';

--- a/lang/en/qtype_matrix.php
+++ b/lang/en/qtype_matrix.php
@@ -43,67 +43,81 @@ Kprime questions consist of an item stem and four corresponding answer statement
 </ul>';
 }
 
-
 $string['pluginname_link'] = 'question/type/matrix';
+$string['privacy:metadata'] = 'The Kprime/Matrix Question Type plugin does not store any personal data.';
 
-// Gradings.
+// Edit form
+$string['multipleallowed'] = 'Allow multiple responses per answer statement?';
+
+$string['grademethod'] = 'Scoring method';
 $string['all'] = 'Subpoints';
 $string['kany'] = 'Kprime (at least one correct, no wrong answer)  ';
 $string['kprime'] = 'Kprime1/0';
 $string['difference'] = 'Difference';
 
-// Strings.
-$string['true'] = 'True';
-$string['false'] = 'False';
+$string['use_dnd_ui'] = 'Use drag &amp; drop ?';
 
-// Form.
-$string['multipleallowed'] = 'Allow multiple responses per answer statement?';
+$string['shuffleanswers'] = 'Shuffle answer statements?';
+$string['shuffleanswers_help'] = 'If enabled, the order of the answer statements is randomly shuffled for each attempt, provided that “Shuffle within questions” in the activity settings is also enabled.';
 
-$string['grademethod'] = 'Scoring method';
+// Edit form, matrix start
+$string['matrixheader'] = 'Response matrix';
 
-$string['rowsheader'] = 'Matrix rows';
-$string['rowsheader_desc'] = '<p>Shorttext will be used when it\'s present, with the longer text as a tooltip.<br />Be mindful of how this will be displayed</p>
-<p>Students can select multiple or single columns per row, depending on how the question has been configured, and each row receives a grade, defined by one of the grading methods.</p>
-<p>The final grade for the question is an average of their grades for each of the rows with the exeption of the Kprime type where all answers have to be correct.</p>';
+$string['refresh_matrix'] = 'Refresh response matrix';
 
+// Rows
 $string['rows_shorttext'] = 'Answer statement';
 $string['rows_description'] = 'Description';
 $string['rows_feedback'] = 'Feedback';
 
-$string['colsheader'] = 'Matrix columns';
-$string['colsheader_desc'] = '<p>Shorttext will be used when it\'s present, with the longer text as a tooltip.<br />Be mindful of how this will be displayed.</p>
-<p>Students can select multiple or single columns per row, depending on how the question has been configured, and each row receives a grade, defined by one of the grading methods.</p>
-<p>The final grade for the question is an average of their grades for each of the rows with the exeption of the Kprime type where all answers have to be correct.</p>';
-
+// Cols
 $string['cols_shorttext'] = 'Response';
 $string['cols_description'] = 'Description';
+// Default values for new question cols
+$string['true'] = 'True';
+$string['false'] = 'False';
+// Autopass grade for row
+$string['editform_colheader_autopass'] = 'Auto pass row';
 
-$string['refresh_matrix'] = 'Refresh response matrix';
-
-$string['matrixheader'] = 'Response matrix';
-
+// Form validation
 $string['mustdefine1by1'] = 'You must define at least one answer statement and two responses';
-$string['mustaddupto100'] = 'The sum of all non negative weights in each row must be 100%';
-$string['weightednomultiple'] = 'It doesn\'t make sense to choose weighted grading with multiple answers not allowed';
 $string['oneanswerperrow'] = 'You must provide an answer for each row';
+// Edit form, matrix end
 
-$string['shuffleanswers'] = 'Shuffle answer statements?';
-$string['shuffleanswers_help'] = 'If enabled, the order of the answer statements is randomly shuffled for each attempt, provided that “Shuffle within questions” in the activity settings is also enabled.';
+// Global options
 $string['show_non_kprime_gui'] = 'Show graphical user interface for options which are not strictly kprime matrix options (more than four rows, more than two columsn, multiple options).';
-
 $string['allow_dnd_ui'] = 'Allow usage of Drag&Drop UI';
 $string['allow_dnd_ui_descr'] = 'If allowed, the teachers will have the possibility to enable the Drag&Drop feature to any Matrix questions';
-$string['use_dnd_ui'] = 'Use drag &amp; drop ?';
-$string['privacy:metadata'] = 'The Kprime/Matrix Question Type plugin does not store any personal data.';
-$string['correctresponse'] = 'Correct Response';
-
-// Attempt syntax migration
-$string['attemptdatamigration_baddata'] = 'Matrix question attempt contains bad data and cannot be migrated';
+$string['allow_autopass'] = 'Allow automatically passing grading rows in attempts';
+$string['allow_autopass_desc'] = 'Sometimes you identify badly worded questions/rows after the fact'
+    . ' and just want to quickly give everyone a point.';
 
 // Question display
 $string['cellarialabel'] = 'Select possible answer {$a->answershorttext} for item {$a->itemshorttext}';
+$string['correctresponse'] = 'Correct Response';
 
 // Regrading
 $string['regrade_different_nr_rows'] = 'Cannot regrade because question versions have different number of rows';
 $string['regrade_different_nr_cols'] = 'Cannot regrade because question versions have different number of columns';
 $string['regrade_switching_multiple_too_many_correct'] = 'Cannot regrade because the nr of answers per row is different';
+
+// Attempt syntax migration
+$string['attemptdatamigration_baddata'] = 'Matrix question attempt contains bad data and cannot be migrated';
+
+// Unused section
+// FIXME: rowsheader strings are not used right now.
+$string['rowsheader'] = 'Matrix rows';
+$string['rowsheader_desc'] = '<p>Shorttext will be used when it\'s present, with the longer text as a tooltip.<br />Be mindful of how this will be displayed</p>
+<p>Students can select multiple or single columns per row, depending on how the question has been configured, and each row receives a grade, defined by one of the grading methods.</p>
+<p>The final grade for the question is an average of their grades for each of the rows with the exeption of the Kprime type where all answers have to be correct.</p>';
+
+// FIXME: colsheader strings are not used right now.
+$string['colsheader'] = 'Matrix columns';
+$string['colsheader_desc'] = '<p>Shorttext will be used when it\'s present, with the longer text as a tooltip.<br />Be mindful of how this will be displayed.</p>
+<p>Students can select multiple or single columns per row, depending on how the question has been configured, and each row receives a grade, defined by one of the grading methods.</p>
+<p>The final grade for the question is an average of their grades for each of the rows with the exeption of the Kprime type where all answers have to be correct.</p>';
+// FIXME: mustaddupto100 string not used right now.
+$string['mustaddupto100'] = 'The sum of all non negative weights in each row must be 100%';
+// FIXME: weightednomultiple string not used right now.
+$string['weightednomultiple'] = 'It doesn\'t make sense to choose weighted grading with multiple answers not allowed';
+

--- a/lang/en/qtype_matrix.php
+++ b/lang/en/qtype_matrix.php
@@ -43,67 +43,84 @@ Kprime questions consist of an item stem and four corresponding answer statement
 </ul>';
 }
 
-
 $string['pluginname_link'] = 'question/type/matrix';
+$string['privacy:metadata'] = 'The Kprime/Matrix Question Type plugin does not store any personal data.';
 
-// Gradings.
+// Edit form
+$string['multipleallowed'] = 'Allow multiple responses per answer statement?';
+
+$string['grademethod'] = 'Scoring method';
 $string['all'] = 'Subpoints';
 $string['kany'] = 'Kprime (at least one correct, no wrong answer)  ';
 $string['kprime'] = 'Kprime1/0';
 $string['difference'] = 'Difference';
 
-// Strings.
+$string['use_dnd_ui'] = 'Use drag &amp; drop ?';
+
+$string['shuffleanswers'] = 'Shuffle answer statements?';
+$string['shuffleanswers_help'] = 'If enabled, the order of the answer statements is randomly shuffled for each attempt, provided that “Shuffle within questions” in the activity settings is also enabled.';
+
+// Edit form, matrix start
+$string['matrixheader'] = 'Response matrix';
+
+$string['refresh_matrix'] = 'Refresh response matrix';
+
+// Rows
+$string['rows_shorttext'] = 'Answer statement';
+$string['rows_description'] = 'Description';
+$string['rows_feedback'] = 'Feedback';
+
+// Cols
+$string['cols_shorttext'] = 'Response';
+$string['cols_description'] = 'Description';
+// Default values for new question cols
 $string['true'] = 'True';
 $string['false'] = 'False';
+// Autopass grade for row
+$string['editform_colheader_autopass'] = 'Award free points';
 
-// Form.
-$string['multipleallowed'] = 'Allow multiple responses per answer statement?';
+// Form validation
+$string['mustdefine1by1'] = 'You must define at least one answer statement and two responses';
+$string['oneanswerperrow'] = 'You must provide an answer for each row';
+// Edit form, matrix end
 
-$string['grademethod'] = 'Scoring method';
+// Global options
+$string['show_non_kprime_gui'] = 'Show graphical user interface for options which are not strictly kprime matrix options (more than four rows, more than two columsn, multiple options).';
+$string['allow_dnd_ui'] = 'Allow usage of Drag&Drop UI';
+$string['allow_dnd_ui_descr'] = 'If allowed, the teachers will have the possibility to enable the Drag&Drop feature to any Matrix questions';
+$string['allow_autopass'] = 'Allow free points for items.';
+$string['allow_autopass_desc'] = 'Grading staff (e.g. teachers) can give each student points regardless if the answer was correct. This is useful to credit students with a free point after the quiz, if the item in a question was invalid or problematic.
+Participants will see an information about the free point in the quiz review.'
+    . ' and just want to quickly give everyone a point.';
 
+// Question display
+$string['cellarialabel'] = 'Select possible answer {$a->answershorttext} for item {$a->itemshorttext}';
+$string['correctresponse'] = 'Correct Response';
+$string['autopassingrow'] = 'This answer was awarded points regardless of the answer.';
+
+// Regrading
+$string['regrade_different_nr_rows'] = 'Cannot regrade because question versions have different number of rows';
+$string['regrade_different_nr_cols'] = 'Cannot regrade because question versions have different number of columns';
+$string['regrade_switching_multiple_too_many_correct'] =
+    'Cannot regrade because one version has multiple correct answers and the other is in single mode';
+
+// Attempt syntax migration
+$string['attemptdatamigration_baddata'] = 'Matrix question attempt contains bad data and cannot be migrated';
+
+// Unused section
+// FIXME: rowsheader strings are not used right now.
 $string['rowsheader'] = 'Matrix rows';
 $string['rowsheader_desc'] = '<p>Shorttext will be used when it\'s present, with the longer text as a tooltip.<br />Be mindful of how this will be displayed</p>
 <p>Students can select multiple or single columns per row, depending on how the question has been configured, and each row receives a grade, defined by one of the grading methods.</p>
 <p>The final grade for the question is an average of their grades for each of the rows with the exeption of the Kprime type where all answers have to be correct.</p>';
 
-$string['rows_shorttext'] = 'Answer statement';
-$string['rows_description'] = 'Description';
-$string['rows_feedback'] = 'Feedback';
-
+// FIXME: colsheader strings are not used right now.
 $string['colsheader'] = 'Matrix columns';
 $string['colsheader_desc'] = '<p>Shorttext will be used when it\'s present, with the longer text as a tooltip.<br />Be mindful of how this will be displayed.</p>
 <p>Students can select multiple or single columns per row, depending on how the question has been configured, and each row receives a grade, defined by one of the grading methods.</p>
 <p>The final grade for the question is an average of their grades for each of the rows with the exeption of the Kprime type where all answers have to be correct.</p>';
-
-$string['cols_shorttext'] = 'Response';
-$string['cols_description'] = 'Description';
-
-$string['refresh_matrix'] = 'Refresh response matrix';
-
-$string['matrixheader'] = 'Response matrix';
-
-$string['mustdefine1by1'] = 'You must define at least one answer statement and two responses';
+// FIXME: mustaddupto100 string not used right now.
 $string['mustaddupto100'] = 'The sum of all non negative weights in each row must be 100%';
+// FIXME: weightednomultiple string not used right now.
 $string['weightednomultiple'] = 'It doesn\'t make sense to choose weighted grading with multiple answers not allowed';
-$string['oneanswerperrow'] = 'You must provide an answer for each row';
 
-$string['shuffleanswers'] = 'Shuffle answer statements?';
-$string['shuffleanswers_help'] = 'If enabled, the order of the answer statements is randomly shuffled for each attempt, provided that “Shuffle within questions” in the activity settings is also enabled.';
-$string['show_non_kprime_gui'] = 'Show graphical user interface for options which are not strictly kprime matrix options (more than four rows, more than two columsn, multiple options).';
-
-$string['allow_dnd_ui'] = 'Allow usage of Drag&Drop UI';
-$string['allow_dnd_ui_descr'] = 'If allowed, the teachers will have the possibility to enable the Drag&Drop feature to any Matrix questions';
-$string['use_dnd_ui'] = 'Use drag &amp; drop ?';
-$string['privacy:metadata'] = 'The Kprime/Matrix Question Type plugin does not store any personal data.';
-$string['correctresponse'] = 'Correct Response';
-
-// Attempt syntax migration
-$string['attemptdatamigration_baddata'] = 'Matrix question attempt contains bad data and cannot be migrated';
-
-// Question display
-$string['cellarialabel'] = 'Select possible answer {$a->answershorttext} for item {$a->itemshorttext}';
-
-// Regrading
-$string['regrade_different_nr_rows'] = 'Cannot regrade because question versions have different number of rows';
-$string['regrade_different_nr_cols'] = 'Cannot regrade because question versions have different number of columns';
-$string['regrade_switching_multiple_too_many_correct'] = 'Cannot regrade because the nr of answers per row is different';

--- a/question.php
+++ b/question.php
@@ -402,6 +402,19 @@ class qtype_matrix_question extends question_graded_automatically_with_countback
     }
 
     /**
+     * Checks if any row in this question version automatically receives a passing grade.
+     * @return bool
+     */
+    public function has_autopass_rows(): bool {
+        foreach ($this->rows as $row) {
+            if ($row->autopass) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Grade a response to the question, returning a fraction between
      * get_min_fraction() and 1.0, and the corresponding {@link question_state}
      * right, partial or wrong.

--- a/question.php
+++ b/question.php
@@ -19,6 +19,7 @@
  *
  */
 
+use qtype_matrix\local\setting;
 use qtype_matrix\local\lang;
 use qtype_matrix\local\qtype_matrix_grading;
 
@@ -126,6 +127,14 @@ class qtype_matrix_question extends question_graded_automatically_with_countback
      */
     public function weight(int $rowid, int $colid):float {
         return (float) $this->weights[$rowid][$colid] ?? 0;
+    }
+
+    public function autopass_row(int $rowindex): bool {
+        if (!setting::allow_autopass() || !$this->order) {
+            return false;
+        }
+        $rowid = $this->order[$rowindex];
+        return $this->rows[$rowid]->autopass;
     }
 
     /**

--- a/question.php
+++ b/question.php
@@ -19,6 +19,7 @@
  *
  */
 
+use qtype_matrix\local\setting;
 use qtype_matrix\local\lang;
 use qtype_matrix\local\qtype_matrix_grading;
 
@@ -126,6 +127,14 @@ class qtype_matrix_question extends question_graded_automatically_with_countback
      */
     public function weight(int $rowid, int $colid):float {
         return (float) $this->weights[$rowid][$colid] ?? 0;
+    }
+
+    public function autopass_row(int $rowindex): bool {
+        if (!setting::allow_autopass() || !$this->order) {
+            return false;
+        }
+        $rowid = $this->order[$rowindex];
+        return $this->rows[$rowid]->autopass;
     }
 
     /**
@@ -305,20 +314,28 @@ class qtype_matrix_question extends question_graded_automatically_with_countback
             return get_string('regrade_different_nr_cols', 'qtype_matrix');
         }
 
-        // FIXME: This would currently prevent a workflow where we change from single to multiple
-        //        and mark all columns as correct to remove all points for all participants
-        //        to then give everyone the same bonus point.
-        // TODO: This probably must be activated because going from multiple to single and a user that checked all, his answer is now always correct
-//        if ($oldmatrixversion->multiple != $this->multiple) {
-//            $thisrows = array_keys($this->rows);
-//            $otherrows = array_keys($otherversion->rows);
-//            foreach ($thisrows as $rowindex => $rowid) {
-//                $otherrowid = $otherrows[$rowindex];
-//                if ($this->count_correct_answers($rowid) > 1 || $otherversion->count_correct_answers($otherrowid) > 1) {
-//                    return get_string('regrade_switching_multiple_too_many_correct', 'qtype_matrix');
-//                }
-//            }
-//        }
+        // Going from multiple to single or back should only be possible if there was always one correct answer per row
+        if ($oldmatrixversion->multiple != $this->multiple) {
+            // Keep in mind these are the question versions and not the attempt questions,
+            // so the row order here is based on their database ids.
+            $oldmatrixrowids = array_keys($oldmatrixversion->rows);
+            foreach (array_keys($this->rows) as $rowindex => $newrowid) {
+                $oldrowid = $oldmatrixrowids[$rowindex];
+                if (
+                    $this->count_correct_answers($newrowid) > 1
+                    || $oldmatrixversion->count_correct_answers($oldrowid) > 1
+                ) {
+                    return get_string(
+                        'regrade_switching_multiple_too_many_correct',
+                        'qtype_matrix'
+                    );
+                }
+            }
+        }
+        // TODO: What if the other matrix had the correct answer be a different column?
+        //       Should there be a setting to manage this?
+        // TODO: Should there be a setting to allow regrading multiple with rows with > 1 checked columns?
+        //       If so, when should it be OK to do so and when not?
 
         return null;
     }
@@ -390,6 +407,19 @@ class qtype_matrix_question extends question_graded_automatically_with_countback
             $gradevalue += $x[0];
         }
         return $gradevalue;
+    }
+
+    /**
+     * Checks if any row in this question version automatically receives a passing grade.
+     * @return bool
+     */
+    public function has_autopass_rows(): bool {
+        foreach ($this->rows as $row) {
+            if ($row->autopass) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -560,6 +590,8 @@ class qtype_matrix_question extends question_graded_automatically_with_countback
 
     /**
      * Categorise the student's response according to the categories defined by get_possible_responses.
+     * Autopassing a row doesn't factor in here because the statistics should represent the original
+     * given responses and not whether one gets points anyway.
      * @param array $response a response, as might be passed to  grade_response().
      * @return array subpartid => question_classified_response objects.
      *      returns an empty array if no analysis is possible.

--- a/questiontype.php
+++ b/questiontype.php
@@ -195,7 +195,8 @@ class qtype_matrix extends question_type {
                 'description' => $fromform->{$dim.'s_description'}[$i]['text'],
             ];
             if ($isrow) {
-                $dimrecord->feedback = $fromform->{$dim.'s_feedback'}[$i]['text'];
+                $dimrecord->feedback = $fromform->{'rows_feedback'}[$i]['text'];
+                $dimrecord->autopass = $fromform->{'rows_autopass'}[$i];
             }
             $newdimid = $store->{'insert_matrix_'.$dim}($dimrecord);
             if ($newdimid) {
@@ -426,6 +427,7 @@ class qtype_matrix extends question_type {
                     )
                 )
             ];
+            // Note: row autopass values are not imported because a question XML is imported as a new v1 question.
             $index++;
         }
 
@@ -503,6 +505,7 @@ class qtype_matrix extends question_type {
             $output .= $format->writetext($row->feedback['text'], 6);
             $output .= "        </feedback>\n";
             $output .= "    </row>\n";
+            // Note: row autopass values are not exported because a question XML is imported as a new v1 question.
             $rowindex++;
         }
 

--- a/questiontype.php
+++ b/questiontype.php
@@ -196,7 +196,7 @@ class qtype_matrix extends question_type {
             ];
             if ($isrow) {
                 $dimrecord->feedback = $fromform->{'rows_feedback'}[$i]['text'];
-                $dimrecord->autopass = $fromform->{'rows_autopass'}[$i];
+                $dimrecord->autopass = $fromform->{'rows_autopass'}[$i] ?? false;
             }
             $newdimid = $store->{'insert_matrix_'.$dim}($dimrecord);
             if ($newdimid) {

--- a/questiontype.php
+++ b/questiontype.php
@@ -41,6 +41,8 @@ class qtype_matrix extends question_type {
 
     public const DEFAULT_SHUFFLEANSWERS = true;
 
+    public const DEFAULT_ROW_AUTOPASS = false;
+
     public static function clean_data($questiondata, bool $useoptions = false) {
         $datasource = $questiondata;
         if ($useoptions) {

--- a/questiontype.php
+++ b/questiontype.php
@@ -41,6 +41,8 @@ class qtype_matrix extends question_type {
 
     public const DEFAULT_SHUFFLEANSWERS = true;
 
+    public const DEFAULT_ROW_AUTOPASS = false;
+
     public static function clean_data($questiondata, bool $useoptions = false) {
         $datasource = $questiondata;
         if ($useoptions) {
@@ -59,6 +61,9 @@ class qtype_matrix extends question_type {
         $datasource->shuffleanswers = (bool)($datasource->shuffleanswers ?? self::DEFAULT_SHUFFLEANSWERS);
         $datasource->usedndui = (bool)($datasource->usedndui ?? self::DEFAULT_USEDNDUI);
         $datasource->rows ??= [];
+        foreach ($datasource->rows as $row) {
+            $row->autopass = (bool) ($row->autopass ?? self::DEFAULT_ROW_AUTOPASS);
+        }
         $datasource->cols ??= [];
         $datasource->weights ??= [[]];
         return $questiondata;
@@ -121,12 +126,12 @@ class qtype_matrix extends question_type {
      */
     public function get_question_options($questiondata): bool {
         parent::get_question_options($questiondata);
-        $questiondata = self::clean_data($questiondata, true);
 
         $matrix = self::retrieve_matrix($questiondata->id);
         $questiondata->options->rows = $matrix->rows ?? [];
         $questiondata->options->cols = $matrix->cols ?? [];
         $questiondata->options->weights = $matrix->weights ?? [[]];
+        self::clean_data($questiondata, true);
         return true;
     }
 
@@ -176,9 +181,10 @@ class qtype_matrix extends question_type {
      * @param $fromform - the form data containing the dimension's data
      * @param int $matrixid - the matrix id to store dimension data for
      * @param bool $isrow - whether we want to store rows or cols
+     * @param int $questionversion - the version the saved question has
      * @return array - the database ids of existing dimension records for the matrix
      */
-    private function save_dimension($fromform, int $matrixid, bool $isrow):array {
+    private function save_dimension($fromform, int $matrixid, bool $isrow, int $questionversion):array {
         $store = new question_matrix_store();
         $dim = $isrow ? 'row' : 'col';
         $dimids = [];
@@ -193,7 +199,11 @@ class qtype_matrix extends question_type {
                 'description' => $fromform->{$dim.'s_description'}[$i]['text'],
             ];
             if ($isrow) {
-                $dimrecord->feedback = $fromform->{$dim.'s_feedback'}[$i]['text'];
+                $dimrecord->feedback = $fromform->{'rows_feedback'}[$i]['text'];
+                $dimrecord->autopass = false;
+                if ($questionversion > 1) {
+                    $dimrecord->autopass = $fromform->{'rows_autopass'}[$i] ?? false;
+                }
             }
             $newdimid = $store->{'insert_matrix_'.$dim}($dimrecord);
             if ($newdimid) {
@@ -221,8 +231,10 @@ class qtype_matrix extends question_type {
 
 
         $matrix = (object) $store->get_matrix_by_question_id($questionid);
-        $rowids = $this->save_dimension($fromform, $matrix->id,true);
-        $colids = $this->save_dimension($fromform, $matrix->id,false);
+        $questionversions = get_question_version($questionid);
+        $questionversion = $questionversions[array_key_first($questionversions)]->version;
+        $rowids = $this->save_dimension($fromform, $matrix->id,true, $questionversion);
+        $colids = $this->save_dimension($fromform, $matrix->id,false, $questionversion);
 
         // FIXME: We should just not validate the form with true if we changed the option (or dynamically change the form with AJAX)
         // When we switch from multiple answers to single answers (or the other
@@ -402,6 +414,7 @@ class qtype_matrix extends question_type {
         $fromform->rows_shorttext = [];
         $fromform->rows_description = [];
         $fromform->rows_feedback = [];
+        $fromform->rows_autopass = [];
         $index = 0;
         $rowsxml = $data['#']['row'];
 
@@ -424,6 +437,8 @@ class qtype_matrix extends question_type {
                     )
                 )
             ];
+            // Note: Any row autopass values are not imported because a question XML is imported as a new v1 question.
+            $fromform->rows_autopass[$index] = '0';
             $index++;
         }
 
@@ -501,6 +516,7 @@ class qtype_matrix extends question_type {
             $output .= $format->writetext($row->feedback['text'], 6);
             $output .= "        </feedback>\n";
             $output .= "    </row>\n";
+            // Note: row autopass values are not exported because a question XML is imported as a new v1 question.
             $rowindex++;
         }
 

--- a/settings.php
+++ b/settings.php
@@ -28,4 +28,8 @@ if ($ADMIN->fulltree) {
         new lang_string('allow_dnd_ui_descr', 'qtype_matrix'), '0',
         '1', '0'));
 
+    $settings->add(new admin_setting_configcheckbox('qtype_matrix/allow_autopass',
+        new lang_string('allow_autopass', 'qtype_matrix'),
+        new lang_string('allow_autopass_desc', 'qtype_matrix'), '0',
+        '1', '0'));
 }

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,9 @@
 .que.matrix .formulation table.matrix tbody td {
     border-width: 1px;
 }
+.que.matrix .formulation table.matrix tbody tr.autopassrow {
+    background-color: lightgreen;
+}
 .que.matrix .formulation table.matrix td,
 .que.matrix .formulation table.matrix th {
     text-align: left;
@@ -244,7 +247,7 @@
     padding: 0;
     line-height: 1em;
 }
-/* modifications nécessaires à l'affichage correct du mode édition avec le theme_unil */
+/* Modifications necessary for the correct display of edit mode with theme_unil */
 body#page-question-type-matrix #fgroup_id_matrix fieldset {
     margin-left: 0;
 }

--- a/styles.css
+++ b/styles.css
@@ -244,7 +244,7 @@
     padding: 0;
     line-height: 1em;
 }
-/* modifications nécessaires à l'affichage correct du mode édition avec le theme_unil */
+/* Modifications necessary for the correct display of edit mode with theme_unil */
 body#page-question-type-matrix #fgroup_id_matrix fieldset {
     margin-left: 0;
 }

--- a/stylesheets/less/base.less
+++ b/stylesheets/less/base.less
@@ -28,6 +28,10 @@
     }
   }
 
+  tbody tr.autopassrow {
+    background-color: lightgreen;
+  }
+
   td,
   th {
     text-align: left;

--- a/stylesheets/less/dndui.less
+++ b/stylesheets/less/dndui.less
@@ -80,7 +80,7 @@
   }
 }
 
-  /* modifications nécessaires à l'affichage correct du mode édition avec le theme_unil */
+  /* Modifications necessary for the correct display of edit mode with theme_unil */
 
 body#page-question-type-matrix #fgroup_id_matrix fieldset {
   margin-left: 0;
@@ -98,9 +98,5 @@ body#page-question-type-matrix div#region-main {
   font-size: 22px;
   background-color: white;
   color: black;
-  padding: 0px 5px 5px 5px;
+  padding: 0 5px 5px 5px;
 }
-
-/*
-mod_ND : END
-*/

--- a/templates/question.mustache
+++ b/templates/question.mustache
@@ -11,6 +11,7 @@
         "isreadonly": true,
         "usedndui": false,
         "showfeedback": false,
+        "hasautopassrows": true,
         "expiredquestion": false,
         "errormessage": "",
         "questiontext": "The question text for the question",
@@ -28,12 +29,12 @@
         ],
         "rows": [
             {
-                "lastrow": false,
                 "header": {
                     "shorttext": "Short text for the first row item",
                     "descriptionid": "rowheader1",
                     "description": "Longer description for the first row item"
                 },
+                "rowcssclasses": "autopassrow",
                 "cells": [
                     {
                         "cellclass": "row0col0",
@@ -56,15 +57,16 @@
                         "feedbackimage": "ICONHTML"
                     }
                 ],
-                "feedback": "ICONHTML_AND_FEEDBACK"
+                "feedback": "ICONHTML_AND_FEEDBACK",
+                "autopassrow": true
             },
             {
-                "lastrow": true,
                 "header": {
                     "shorttext": "Short text for the second row item",
                     "descriptionid": "rowheader2",
                     "description": "Longer description for the second row item"
                 },
+                "rowcssclasses": "lastrow",
                 "cells": [
                     {
                         "cellclass": "row1col0",
@@ -87,7 +89,8 @@
                         "feedbackimage": "ICONHTML"
                     }
                 ],
-                "feedback": "ICONHTML_AND_FEEDBACK"
+                "feedback": "ICONHTML_AND_FEEDBACK",
+                "autopassrow": false
             }
         ]
     }
@@ -114,11 +117,14 @@ Expired question: This can happen in preview mode.
 {{#showfeedback}}
             <td></td>
 {{/showfeedback}}
+{{#hasautopassrows}}
+            <td></td>
+{{/hasautopassrows}}
         </tr>
     </thead>
     <tbody>
 {{#rows}}
-    <tr{{#lastrow}} class="lastrow"{{/lastrow}}>
+    <tr{{#rowcssclasses}} class="{{ rowcssclasses }}"{{/rowcssclasses}}>
 {{#header}}
         <th scope="row">
             <span class="title"{{#description}} aria-details="{{ descriptionid }}"{{/description}}>{{{ shorttext }}}</span>
@@ -145,6 +151,9 @@ Expired question: This can happen in preview mode.
 {{#showfeedback}}
         <td class="feedbackcell">{{{ feedback }}}</td>
 {{/showfeedback}}
+{{#hasautopassrows}}
+        <td>{{#autopassrow}}{{#str}}autopassingrow, qtype_matrix{{/str}}{{/autopassrow}}</td>
+{{/hasautopassrows}}
     </tr>
 {{/rows}}
     </tbody>

--- a/templates/question.mustache
+++ b/templates/question.mustache
@@ -11,6 +11,7 @@
         "isreadonly": true,
         "usedndui": false,
         "showfeedback": false,
+        "hasautopassrows": true,
         "expiredquestion": false,
         "errormessage": "",
         "questiontext": "The question text for the question",
@@ -28,12 +29,12 @@
         ],
         "rows": [
             {
-                "lastrow": false,
                 "header": {
                     "shorttext": "Short text for the first row item",
                     "descriptionid": "rowheader1",
                     "description": "Longer description for the first row item"
                 },
+                "rowcssclasses": "autopassrow",
                 "cells": [
                     {
                         "cellclass": "row0col0",
@@ -56,15 +57,16 @@
                         "feedbackimage": "ICONHTML"
                     }
                 ],
-                "feedback": "ICONHTML_AND_FEEDBACK"
+                "feedback": "ICONHTML_AND_FEEDBACK",
+                "autopassrow": true
             },
             {
-                "lastrow": true,
                 "header": {
                     "shorttext": "Short text for the second row item",
                     "descriptionid": "rowheader2",
                     "description": "Longer description for the second row item"
                 },
+                "rowcssclasses": "lastrow",
                 "cells": [
                     {
                         "cellclass": "row1col0",
@@ -87,7 +89,8 @@
                         "feedbackimage": "ICONHTML"
                     }
                 ],
-                "feedback": "ICONHTML_AND_FEEDBACK"
+                "feedback": "ICONHTML_AND_FEEDBACK",
+                "autopassrow": false
             }
         ]
     }
@@ -114,11 +117,14 @@ Expired question: This can happen in preview mode.
 {{#showfeedback}}
             <td></td>
 {{/showfeedback}}
+{{#hasautopassrows}}
+            <td></td>
+{{/hasautopassrows}}
         </tr>
     </thead>
     <tbody>
 {{#rows}}
-    <tr{{#lastrow}} class="lastrow"{{/lastrow}}>
+    <tr{{#rowcssclasses}} class="{{ rowcssclasses }}"{{/rowcssclasses}}>
 {{#header}}
         <th scope="row">
             <span class="title"{{#description}} aria-details="{{ descriptionid }}"{{/description}}>{{{ shorttext }}}</span>
@@ -145,6 +151,9 @@ Expired question: This can happen in preview mode.
 {{#showfeedback}}
         <td class="feedbackcell">{{{ feedback }}}</td>
 {{/showfeedback}}
+{{#hasautopassrows}}
+        <td>{{#autopassrow}}<i class="fas fa-info-circle"></i> {{#str}}autopassingrow, qtype_matrix{{/str}}{{/autopassrow}}</td>
+{{/hasautopassrows}}
     </tr>
 {{/rows}}
     </tbody>

--- a/tests/backup_test.php
+++ b/tests/backup_test.php
@@ -17,7 +17,9 @@
 namespace qtype_matrix;
 
 use mod_quiz\backup\repeated_restore_test;
+use qtype_matrix\local\setting;
 use question_bank;
+use core_question_generator;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -36,15 +38,19 @@ require_once $CFG->dirroot . '/course/externallib.php';
 final class backup_test extends \advanced_testcase {
 
     /**
-     * Duplicate quiz with a matrix question, and check it worked,
-     * i.e. the copy of the question looks the same but is not exactly the same (db ids)
+     * Duplicate quiz with two matrix question versions, and check it worked,
+     * i.e. the copy of the questions look the same but is not exactly the same (db ids)
+     * @dataProvider duplicate_matrix_question_data_provider
      */
-    public function test_duplicate_matrix_question(): void {
+    public function test_duplicate_matrix_question(
+        bool $allowautopass
+    ): void {
         global $DB;
         $this->resetAfterTest();
         $this->setAdminUser();
-
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $allowautopass, 'qtype_matrix');
         $coregenerator = $this->getDataGenerator();
+        /** @var core_question_generator $questiongenerator */
         $questiongenerator = $coregenerator->get_plugin_generator('core_question');
 
         // Create a course with a page that embeds a question.
@@ -55,66 +61,80 @@ final class backup_test extends \advanced_testcase {
         $cat = $questiongenerator->create_question_category(['contextid' => $quizcontext->id]);
         $question = $questiongenerator->create_question('matrix', 'default', ['category' => $cat->id]);
 
+        $questionv2 = $questiongenerator->update_question($question, 'default', [
+            'name' => 'V2',
+            'rows_autopass[0]' => true,
+            'rows_autopass[2]' => true,
+        ]);
         // Store some counts.
         $numquizzes = count(get_fast_modinfo($course)->instances['quiz']);
         $nummatrixquestions = $DB->count_records('question', ['qtype' => 'matrix']);
 
         // Duplicate the page.
+        // As the questions are inside a quiz category, they will be copied not mapped
         duplicate_module($course, get_fast_modinfo($course)->get_cm($quiz->cmid));
 
         // Verify the copied quiz exists.
         $this->assertCount($numquizzes + 1, get_fast_modinfo($course)->instances['quiz']);
 
-        // Verify the copied question.
-        $this->assertEquals($nummatrixquestions + 1, $DB->count_records('question', ['qtype' => 'matrix']));
-        $newmatrixid = $DB->get_field_sql("
+        // Verify questions have been copied.
+        $this->assertEquals($nummatrixquestions * 2, $DB->count_records('question', ['qtype' => 'matrix']));
+        $copiedv2matrixid = $DB->get_field_sql("
                 SELECT MAX(id)
                   FROM {question}
-                 WHERE qtype = ?
-                ", ['matrix']);
-        $questiondata = question_bank::load_question_data($question->id);
-        $matrixdata = question_bank::load_question_data($newmatrixid);
+                 WHERE qtype = ? AND name = ?
+                ", ['matrix', 'V2']);
+        $questionv2data = question_bank::load_question_data($questionv2->id);
+        $matrixv2data = question_bank::load_question_data($copiedv2matrixid);
 
-        $this->assertNotEquals($questiondata->id, $matrixdata->id);
-        $this->assertEquals($questiondata->name, $matrixdata->name);
-        $this->assertEquals($questiondata->questiontext, $matrixdata->questiontext);
-        $this->assertEquals($questiondata->generalfeedback, $matrixdata->generalfeedback);
-        $this->assertEquals($questiondata->defaultmark, $matrixdata->defaultmark);
-        $this->assertEquals($questiondata->penalty, $matrixdata->penalty);
-        $this->assertEquals($questiondata->options->grademethod, $matrixdata->options->grademethod);
-        $this->assertEquals($questiondata->options->multiple, $matrixdata->options->multiple);
-        $this->assertEquals($questiondata->options->usedndui, $matrixdata->options->usedndui);
-        $this->assertEquals($questiondata->options->shuffleanswers, $matrixdata->options->shuffleanswers);
-        $questiondatarows = array_values($questiondata->options->rows);
-        $matrixdatarows = array_values($matrixdata->options->rows);
-        foreach ($questiondatarows as $index => $row) {
-            $this->assertNotEquals($questiondatarows[$index]->id, $matrixdatarows[$index]->id);
-            $this->assertNotEquals($questiondatarows[$index]->matrixid, $matrixdatarows[$index]->matrixid);
-            $this->assertEquals($questiondatarows[$index]->shorttext, $matrixdatarows[$index]->shorttext);
-            $this->assertEquals($questiondatarows[$index]->description['text'], $matrixdatarows[$index]->description['text']);
-            $this->assertEquals($questiondatarows[$index]->description['format'], $matrixdatarows[$index]->description['format']);
-            $this->assertEquals($questiondatarows[$index]->feedback['text'], $matrixdatarows[$index]->feedback['text']);
-            $this->assertEquals($questiondatarows[$index]->feedback['format'], $matrixdatarows[$index]->feedback['format']);
+        $this->assertNotEquals($questionv2data->id, $matrixv2data->id);
+        $this->assertEquals($questionv2data->name, $matrixv2data->name);
+        $this->assertEquals($questionv2data->questiontext, $matrixv2data->questiontext);
+        $this->assertEquals($questionv2data->generalfeedback, $matrixv2data->generalfeedback);
+        $this->assertEquals($questionv2data->defaultmark, $matrixv2data->defaultmark);
+        $this->assertEquals($questionv2data->penalty, $matrixv2data->penalty);
+        $this->assertEquals($questionv2data->options->grademethod, $matrixv2data->options->grademethod);
+        $this->assertEquals($questionv2data->options->multiple, $matrixv2data->options->multiple);
+        $this->assertEquals($questionv2data->options->usedndui, $matrixv2data->options->usedndui);
+        $this->assertEquals($questionv2data->options->shuffleanswers, $matrixv2data->options->shuffleanswers);
+        $questionv2datarows = array_values($questionv2data->options->rows);
+        $matrixdatarows = array_values($matrixv2data->options->rows);
+        foreach ($questionv2datarows as $index => $row) {
+            $this->assertNotEquals($questionv2datarows[$index]->id, $matrixdatarows[$index]->id);
+            $this->assertNotEquals($questionv2datarows[$index]->matrixid, $matrixdatarows[$index]->matrixid);
+            $this->assertEquals($questionv2datarows[$index]->shorttext, $matrixdatarows[$index]->shorttext);
+            $this->assertEquals($questionv2datarows[$index]->description['text'], $matrixdatarows[$index]->description['text']);
+            $this->assertEquals($questionv2datarows[$index]->description['format'], $matrixdatarows[$index]->description['format']);
+            $this->assertEquals($questionv2datarows[$index]->feedback['text'], $matrixdatarows[$index]->feedback['text']);
+            $this->assertEquals($questionv2datarows[$index]->feedback['format'], $matrixdatarows[$index]->feedback['format']);
+            $this->assertEquals($questionv2datarows[$index]->autopass, $matrixdatarows[$index]->autopass);
         }
 
-        $questiondatacols = array_values($questiondata->options->cols);
-        $matrixdatacols = array_values($matrixdata->options->cols);
-        foreach ($questiondatacols as $index => $col) {
-            $this->assertNotEquals($questiondatacols[$index]->id, $matrixdatacols[$index]->id);
-            $this->assertNotEquals($questiondatacols[$index]->matrixid, $matrixdatacols[$index]->matrixid);
-            $this->assertEquals($questiondatacols[$index]->shorttext, $matrixdatacols[$index]->shorttext);
-            $this->assertEquals($questiondatacols[$index]->description['text'], $matrixdatacols[$index]->description['text']);
-            $this->assertEquals($questiondatacols[$index]->description['format'], $matrixdatacols[$index]->description['format']);
+        $questionv2datacols = array_values($questionv2data->options->cols);
+        $matrixv2datacols = array_values($matrixv2data->options->cols);
+        foreach ($questionv2datacols as $index => $col) {
+            $this->assertNotEquals($questionv2datacols[$index]->id, $matrixv2datacols[$index]->id);
+            $this->assertNotEquals($questionv2datacols[$index]->matrixid, $matrixv2datacols[$index]->matrixid);
+            $this->assertEquals($questionv2datacols[$index]->shorttext, $matrixv2datacols[$index]->shorttext);
+            $this->assertEquals($questionv2datacols[$index]->description['text'], $matrixv2datacols[$index]->description['text']);
+            $this->assertEquals($questionv2datacols[$index]->description['format'], $matrixv2datacols[$index]->description['format']);
         }
-        $questiondataweights = array_values($questiondata->options->weights);
-        $matrixdataweights = array_values($matrixdata->options->weights);
-        foreach ($questiondataweights as $rowindex => $colarrays) {
+        $questionv2dataweights = array_values($questionv2data->options->weights);
+        $matrixv2dataweights = array_values($matrixv2data->options->weights);
+        foreach ($questionv2dataweights as $rowindex => $colarrays) {
             $questiondatacolvalues = array_values($colarrays);
-            $matrixdatacolvalues = array_values($matrixdataweights[$rowindex]);
+            $matrixdatacolvalues = array_values($matrixv2dataweights[$rowindex]);
             foreach ($questiondatacolvalues as $colindex => $colvalue) {
                 $this->assertEquals($colvalue, $matrixdatacolvalues[$colindex]);
             }
         }
+    }
+
+    public function duplicate_matrix_question_data_provider() {
+        return [
+            'No Autopass' => [false],
+            'Autopass on' => [true],
+        ];
     }
 
     /**

--- a/tests/behat/grading.feature
+++ b/tests/behat/grading.feature
@@ -46,7 +46,6 @@ Feature: Grading and regrading using new versions of matrix questions should wor
     And I press "Finish attempt ..."
     And I press "Submit all and finish"
     And I click on "Submit all and finish" "button" in the "Submit all your answers and finish?" "dialogue"
-#    And I should see "BOOM"
     And I should see "Mark 0.00 out of"
     And I log out
 

--- a/tests/behat/makecopy.feature
+++ b/tests/behat/makecopy.feature
@@ -17,43 +17,57 @@ Feature: Test duplicating a matrix question via makecopy in qbank_editquestion
     And the following "question categories" exist:
       | contextlevel | reference | name           |
       | Course       | C1        | Test questions |
+    And the following config values are set as admin:
+      | config | value | plugin |
+      | allow_autopass | 1 | qtype_matrix |
 
-  Scenario: Copy a Matrix question via qbank_editquestion and makecopy,
-    change the copy and ensure the original does not change
+  Scenario: Copy the second version of a Matrix question with autopassed rows via qbank_editquestion and makecopy,
+    change the copy and ensure the original does not change and the copy does not have autopassed rows anymore
     When I am on the "Course 1" "core_question > course question bank" page logged in as teacher
     And I press "Create a new question ..."
     And I set the field "Matrix/Kprime" to "1"
     And I press "Add"
+    And I should not see "Award free points"
     And I set the following fields to these values:
-      | Question name | matrix-001                                        |
+      | Question name | matrix-001 v1                                     |
       | Question text | Default K-Prime question                          |
       | ID number     | 123                                               |
-      | id_shuffleanswers | 1                                        |
+      | id_shuffleanswers | 1                                             |
       | rows_shorttext[0] | one                                           |
       | rows_shorttext[1] | two                                           |
-      | rows_shorttext[2] | three                                           |
-      | rows_shorttext[3] | four                                           |
-      | cols_shorttext[0] | col1                                           |
-      | cols_shorttext[1] | col2                                           |
+      | rows_shorttext[2] | three                                         |
+      | rows_shorttext[3] | four                                          |
+      | cols_shorttext[0] | col1                                          |
+      | cols_shorttext[1] | col2                                          |
     And I press "id_submitbutton"
-    Then I should see "matrix-001"
+    Then I should see "matrix-001 v1"
+    And I am on the "matrix-001 v1" "core_question > edit" page
+    And I should see "Award free points"
+    And I set the following fields to these values:
+      | Question name | matrix-001 v2                                     |
+      | rows_autopass[0] | 1                                              |
+      | rows_autopass[2] | 1                                              |
+    And I press "id_submitbutton"
+    And I should see "matrix-001 v2"
+    And I should see "v2" in the table row containing "matrix-001"
     And I choose "Duplicate" action for "matrix-001" in the question bank
+    And I should not see "Award free points"
     And I set the following fields to these values:
       | Question name | matrix-002                                        |
       | Question text | Another K-Prime question                          |
       | ID number     | 123-Nr2                                           |
-      | id_shuffleanswers | 0                                        |
-      | rows_shorttext[0] | five                                           |
+      | id_shuffleanswers | 0                                             |
+      | rows_shorttext[0] | five                                          |
       | rows_shorttext[1] | six                                           |
-      | rows_shorttext[2] | seven                                           |
-      | rows_shorttext[3] | eight                                           |
-      | cols_shorttext[0] | col3                                           |
-      | cols_shorttext[1] | col4                                           |
+      | rows_shorttext[2] | seven                                         |
+      | rows_shorttext[3] | eight                                         |
+      | cols_shorttext[0] | col3                                          |
+      | cols_shorttext[1] | col4                                          |
     And I press "id_submitbutton"
     Then I should see "matrix-001"
     And I should see "matrix-002"
-    When I am on the "matrix-001" "core_question > edit" page logged in as teacher
-    Then the field "Question name" matches value "matrix-001"
+    When I am on the "matrix-001 v2" "core_question > edit" page logged in as teacher
+    Then the field "Question name" matches value "matrix-001 v2"
     And the field "Question text" matches value "Default K-Prime question"
     And the field "ID number" matches value "123"
     And the field "id_shuffleanswers" matches value "1"
@@ -61,5 +75,7 @@ Feature: Test duplicating a matrix question via makecopy in qbank_editquestion
     And the field "rows_shorttext[1]" matches value "two"
     And the field "rows_shorttext[2]" matches value "three"
     And the field "rows_shorttext[3]" matches value "four"
+    And the field "rows_autopass[0]" matches value "1"
+    And the field "rows_autopass[2]" matches value "1"
     And the field "cols_shorttext[0]" matches value "col1"
     And the field "cols_shorttext[1]" matches value "col2"

--- a/tests/behat/versions.feature
+++ b/tests/behat/versions.feature
@@ -16,12 +16,16 @@ Feature: Managing matrix question versions via the form should work
     And the following "question categories" exist:
       | contextlevel | reference | name           |
       | Course       | C1        | Test questions |
+    And the following config values are set as admin:
+      | config | value | plugin |
+      | allow_autopass | 1 | qtype_matrix |
 
   Scenario: Create a first version, edit it and save without changes. Currently a v2 is created anyway.
     When I am on the "Course 1" "core_question > course question bank" page logged in as teacher
     And I press "Create a new question ..."
     And I set the field "Matrix/Kprime" to "1"
     And I press "Add"
+    And I should not see "Award free points"
     And I set the following fields to these values:
       | Question name | matrix-001                                        |
       | Question text | Default K-Prime question                          |
@@ -37,6 +41,7 @@ Feature: Managing matrix question versions via the form should work
     And I should see "matrix-001"
     And I should see "v1" in the table row containing "matrix-001"
     And I am on the "matrix-001" "core_question > edit" page
+    And I should see "Award free points"
     And I press "id_submitbutton"
     And I should see "matrix-001"
     And I should see "v2" in the table row containing "matrix-001"

--- a/tests/fixtures/autopass_question_to_import.xml
+++ b/tests/fixtures/autopass_question_to_import.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<question type="matrix">
+    <name>
+        <text>Matrix question</text>
+    </name>
+    <questiontext format="html">
+        <text><![CDATA[<p>Questiontext</p>]]></text>
+    </questiontext>
+    <generalfeedback format="html">
+        <text><![CDATA[<p>General Feedback</p>]]></text>
+    </generalfeedback>
+    <defaultgrade>1</defaultgrade>
+    <penalty>1</penalty>
+    <hidden>0</hidden>
+    <grademethod>kprime</grademethod>
+    <multiple>0</multiple>
+    <usedndui>0</usedndui>
+    <shuffleanswers>1</shuffleanswers>
+    <row>
+        <shorttext>row0shorttext</shorttext>
+        <description format="html">
+            <text><![CDATA[<p>row0description</p>]]></text>
+        </description>
+        <feedback format="html">
+            <text><![CDATA[<p>row0feedback</p>]]></text>
+        </feedback>
+        <autopass>1</autopass>
+    </row>
+    <row>
+        <shorttext>row1shorttext</shorttext>
+        <description format="html">
+            <text><![CDATA[<p>row1description</p>]]></text>
+        </description>
+        <feedback format="html">
+            <text><![CDATA[<p>row1feedback</p>]]></text>
+        </feedback>
+        <autopass>1</autopass>
+    </row>
+    <row>
+        <shorttext>row2shorttext</shorttext>
+        <description format="html">
+            <text><![CDATA[<p>row2description</p>]]></text>
+        </description>
+        <feedback format="html">
+            <text><![CDATA[<p>row2feedback</p>]]></text>
+        </feedback>
+    </row>
+    <row>
+        <shorttext>row3shorttext</shorttext>
+        <description format="html">
+            <text><![CDATA[<p>row3description</p>]]></text>
+        </description>
+        <feedback format="html">
+            <text><![CDATA[<p>row3feedback</p>]]></text>
+        </feedback>
+        <autopass>0</autopass>
+    </row>
+    <col>
+        <shorttext>col0shorttext</shorttext>
+        <description format="html">
+            <text><![CDATA[<p>col0description</p>]]></text>
+        </description>
+    </col>
+    <col>
+        <shorttext>col1shorttext</shorttext>
+        <description format="html">
+            <text><![CDATA[<p>col1description</p>]]></text>
+        </description>
+    </col>
+    <col>
+        <shorttext>col2shorttext</shorttext>
+        <description format="html">
+            <text><![CDATA[<p>col2description</p>]]></text>
+        </description>
+    </col>
+    <weights-of-row>
+        <weight-of-col>1</weight-of-col>
+        <weight-of-col>0</weight-of-col>
+        <weight-of-col>0</weight-of-col>
+    </weights-of-row>
+    <weights-of-row>
+        <weight-of-col>0</weight-of-col>
+        <weight-of-col>1</weight-of-col>
+        <weight-of-col>0</weight-of-col>
+    </weights-of-row>
+    <weights-of-row>
+        <weight-of-col>0</weight-of-col>
+        <weight-of-col>0</weight-of-col>
+        <weight-of-col>1</weight-of-col>
+    </weights-of-row>
+    <weights-of-row>
+        <weight-of-col>1</weight-of-col>
+        <weight-of-col>0</weight-of-col>
+        <weight-of-col>0</weight-of-col>
+    </weights-of-row>
+</question>

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -199,6 +199,30 @@ class qtype_matrix_test_helper extends question_test_helper {
         return self::build_answer_with_matrix($answermatrix);
     }
 
+    /**
+     * @param qtype_matrix_question $question
+     * @return array
+     */
+    public static function make_autopass_only_correct_answer(qtype_matrix_question $question): array {
+        $answermatrix = [];
+        switch ($question->questiontext) {
+            case 'default':
+            case 'nondefault':
+                $answermatrix[0] = [1, 0, 0, 0];
+                $answermatrix[1] = [0, 1, 0, 0];
+                $answermatrix[2] = [0, 0, 0, 0];
+                $answermatrix[3] = [0, 1, 0, 0];
+                break;
+            case 'multipletwocorrect':
+                $answermatrix[0] = [0, 1, 1, 0];
+                $answermatrix[1] = [1, 1, 0, 0];
+                $answermatrix[2] = [0, 0, 1, 1];
+                $answermatrix[3] = [1, 1, 0, 0];
+                break;
+        }
+        return self::build_answer_with_matrix($answermatrix);
+    }
+
     public function get_test_questions():array {
         return ['default', 'nondefault', 'multipletwocorrect'];
     }
@@ -272,7 +296,8 @@ class qtype_matrix_test_helper extends question_test_helper {
             $optionrow->description['text'] = $row->description['text'];
             $optionrow->description['format'] = $row->description['format'];
             $optionrow->feedback['text'] = $row->feedback['text'];
-            $optionrow->feedback['format'] = $row->feedback['format'];;
+            $optionrow->feedback['format'] = $row->feedback['format'];
+            $optionrow->autopass = $row->autopass;
             $questiondata->options->rows[$row->id] = $optionrow;
         }
         $questiondata->options->cols = [];
@@ -318,6 +343,7 @@ class qtype_matrix_test_helper extends question_test_helper {
             $form->rows_feedback = $form->rows_feedback ?? [];
             $form->rows_feedback[$rowindex]['text'] = $row->feedback['text'];
             $form->rows_feedback[$rowindex]['format'] = $row->feedback['format'];
+            $form->rows_autopass[$rowindex] = $row->autopass;
             $rowindex++;
         }
         $colindex = 0;
@@ -471,9 +497,12 @@ class qtype_matrix_test_helper extends question_test_helper {
         ];
         if ($row) {
             $roworcolumn->feedback = [
-                'text' => 'Feedback '.$id,
+                'text' => 'Feedback ' . $id,
                 'format' => FORMAT_HTML
             ];
+            // all odd rows are always autopassing
+            $autopass = ($id % 2 == 0);
+            $roworcolumn->autopass = $autopass;
         }
         return $roworcolumn;
     }

--- a/tests/local/grading/all_test.php
+++ b/tests/local/grading/all_test.php
@@ -19,6 +19,7 @@ namespace qtype_matrix\local\grading;
 defined('MOODLE_INTERNAL') || die();
 
 use advanced_testcase;
+use qtype_matrix\local\setting;
 use qtype_matrix_test_helper;
 use question_attempt_step;
 use testable_question_attempt;
@@ -33,19 +34,22 @@ class all_test extends advanced_testcase {
 
     /**
      * @dataProvider grade_question_data_provider
-     * @return void
      * @throws \coding_exception
      * @throws \dml_exception
      */
     public function test_grade_question(
         string $questiontype,
+        bool   $autopass,
         float  $correctgrade,
         float  $incorrectgrade,
         float  $onerowwronggrade,
         float  $completevariationsgrade,
         float  $incompletepartiallycorrectgrade,
-        float  $incompleteincorrectgrade
+        float  $incompleteincorrectgrade,
+        float  $autopassgrade
     ):void {
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $autopass, 'qtype_matrix');
         $question = qtype_matrix_test_helper::make_question($questiontype);
         $question->shuffleanswers = false;
         $qa = new testable_question_attempt($question, 0);
@@ -72,29 +76,35 @@ class all_test extends advanced_testcase {
 
         $response = qtype_matrix_test_helper::make_incomplete_wrong_answer($question);
         $this->assertEquals($incompleteincorrectgrade, $all->grade_question($question, [4,5,6,7], $response));
+
+        $response = qtype_matrix_test_helper::make_autopass_only_correct_answer($question);
+        $this->assertEquals($autopassgrade, $all->grade_question($question, [4,5,6,7], $response));
     }
 
     public function grade_question_data_provider():array {
         // correct, incorrect, one row wrong, complete with variations, incomplete partially correct, incomplete wrong
         return [
-            'Default question' => ['default', 1, 0, 0.75, 0.5, 0.5, 0],
-            'Nondefault question' => ['nondefault', 1, 0, 0.75, 0.5, 0.5, 0],
-            'multipletwocorrect question' => ['multipletwocorrect', 1, 0, 0.75, 0.25, 0.25, 0],
+            'No autopass, default question' => ['default', false, 1, 0, 0.75, 0.5, 0.5, 0, 0.5],
+            'Autopass on, default question' => ['default', true, 1, 0.5, 1, 0.75, 0.75, 0.5, 1],
+            'No autopass, Nondefault question' => ['nondefault', false, 1, 0, 0.75, 0.5, 0.5, 0, 0.5],
+            'Autopass on, Nondefault question' => ['nondefault', true, 1, 0.5, 1, 0.75, 0.75, 0.5, 1],
+            'No autopass, multipletwocorrect question' => ['multipletwocorrect', false, 1, 0, 0.75, 0.25, 0.25, 0, 0.5],
+            'Autopass on, multipletwocorrect question' => ['multipletwocorrect', true, 1, 0.5, 1, 0.5, 0.5, 0.5, 1],
         ];
     }
 
     /**
      * @dataProvider grade_row_data_provider
-     * @param string $questiontype
-     * @param array $allrowgrades
-     * @return void
      * @throws \coding_exception
      * @throws \dml_exception
      */
     public function test_grade_row(
         string $questiontype,
+        bool $autopass,
         array $allrowgrades
     ):void {
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $autopass, 'qtype_matrix');
         $question = qtype_matrix_test_helper::make_question($questiontype);
         $question->shuffleanswers = false;
         $qa = new \testable_question_attempt($question, 0);
@@ -113,6 +123,7 @@ class all_test extends advanced_testcase {
             $completerowvariationsgrade = $rowgrades[3];
             $incompletepartiallyrowcorrectgrade = $rowgrades[4];
             $incompleteincorrectrowgrade = $rowgrades[5];
+            $autopassrowgrade = $rowgrades[6];
             $wrongmessage = 'Wrong for rowindex '.$rowindex;
             $response = qtype_matrix_test_helper::make_correct_answer($question);
             $this->assertEquals($correctrowgrade, $all->grade_row($question, $rowindex, $response), $wrongmessage);
@@ -131,29 +142,50 @@ class all_test extends advanced_testcase {
 
             $response = qtype_matrix_test_helper::make_incomplete_wrong_answer($question);
             $this->assertEquals($incompleteincorrectrowgrade, $all->grade_row($question, $rowindex, $response), $wrongmessage);
+
+            $response = qtype_matrix_test_helper::make_autopass_only_correct_answer($question);
+            $this->assertEquals($autopassrowgrade, $all->grade_row($question, $rowindex, $response), $wrongmessage);
         }
     }
 
     public function grade_row_data_provider() {
-        // correct, incorrect, one row wrong, complete with row variations, incomplete partially correct, incomplete wrong
+        // correct, incorrect, one row wrong, complete with row variations, incomplete partially correct, incomplete wrong, autopass
         return [
-            'Default question' => ['default', [
-                0 => [1, 0, 0, 1, 1, 0],
-                1 => [1, 0, 1, 1, 1, 0],
-                2 => [1, 0, 1, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0],
+            'No autopass, default question' => ['default', false, [
+                0 => [1, 0, 0, 1, 1, 0, 0],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 1],
             ]],
-            'Nondefault question' => ['nondefault', [
-                0 => [1, 0, 0, 1, 1, 0],
-                1 => [1, 0, 1, 1, 1, 0],
-                2 => [1, 0, 1, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0],
+            'Autopass on, default question' => ['default', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1],
             ]],
-            'multipletwocorrect question' => ['multipletwocorrect', [
-                0 => [1, 0, 0, 1, 1, 0],
-                1 => [1, 0, 1, 0, 0, 0],
-                2 => [1, 0, 1, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0],
+            'No autopass, nondefault question' => ['nondefault', false, [
+                0 => [1, 0, 0, 1, 1, 0, 0],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 1],
+            ]],
+            'Autopass on, nondefault question' => ['nondefault', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1],
+            ]],
+            'No autopass, multipletwocorrect question' => ['multipletwocorrect', false, [
+                0 => [1, 0, 0, 1, 1, 0, 0],
+                1 => [1, 0, 1, 0, 0, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 1],
+            ]],
+            'Autopass on, multipletwocorrect question' => ['multipletwocorrect', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 0, 0, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1],
             ]],
         ];
     }

--- a/tests/local/grading/difference_test.php
+++ b/tests/local/grading/difference_test.php
@@ -20,6 +20,7 @@ defined('MOODLE_INTERNAL') || die();
 
 use advanced_testcase;
 use qtype_matrix\local\grading\difference;
+use qtype_matrix\local\setting;
 use qtype_matrix_test_helper;
 use question_attempt_step;
 use testable_question_attempt;
@@ -34,19 +35,22 @@ class difference_test extends advanced_testcase {
 
     /**
      * @dataProvider grade_question_data_provider
-     * @return void
      * @throws \coding_exception
      * @throws \dml_exception
      */
     public function test_grade_question(
         string $questiontype,
+        bool   $autopass,
         float  $correctgrade,
         float  $incorrectgrade,
         float  $onerowwronggrade,
         float  $completevariationsgrade,
         float  $incompletepartiallycorrectgrade,
-        float  $incompleteincorrectgrade
+        float  $incompleteincorrectgrade,
+        float  $autopassgrade
     ):void {
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $autopass, 'qtype_matrix');
         $question = qtype_matrix_test_helper::make_question($questiontype);
         $question->shuffleanswers = false;
         $qa = new testable_question_attempt($question, 0);
@@ -73,36 +77,63 @@ class difference_test extends advanced_testcase {
 
         $response = qtype_matrix_test_helper::make_incomplete_wrong_answer($question);
         $this->assertEquals($incompleteincorrectgrade, $difference->grade_question($question, [4,5,6,7], $response));
+
+        $response = qtype_matrix_test_helper::make_autopass_only_correct_answer($question);
+        $this->assertEquals($autopassgrade, $difference->grade_question($question, [4,5,6,7], $response));
     }
 
     public function grade_question_data_provider():array {
         // correct, incorrect, one row wrong, complete with variations, incomplete partially correct, incomplete wrong
         return [
-            'Default question' => ['default', 1, 0, 0.75, 0.5, 0.5, 0],
-            'Nondefault question' => ['nondefault', 1, 0, 0.75, 0.5, 0.5, 0],
-            'multipletwocorrect question' => ['multipletwocorrect',
-                1,
-                0,
-                0.75,
-                0.6944444444444444,
-                0.4722222222222222,
-                0
+            'No autopass, default question' => [
+                'default', false,
+                1, 0, 0.75,
+                0.5, 0.5, 0,
+                0.6875
+            ],
+            'Autopass on, default question' => [
+                'default', true,
+                1, 0.5, 1,
+                0.75, 0.75, 0.5,
+                1
+            ],
+            'No autopass, nondefault question' => [
+                'nondefault', false,
+                1, 0, 0.75,
+                0.5, 0.5, 0,
+                0.6875
+            ],
+            'Autopass on, nondefault question' => [
+                'nondefault', true,
+                1, 0.5, 1,
+                0.75, 0.75, 0.5,
+                1
+            ],
+            'No autopass, multipletwocorrect question' => ['multipletwocorrect', false,
+                1, 0, 0.75,
+                0.6944444444444444, 0.4722222222222222, 0,
+                0.8611111111111112
+            ],
+            'Autopass on, multipletwocorrect question' => ['multipletwocorrect', true,
+                1, 0.5, 1,
+                0.7222222222222222, 0.7222222222222222, 0.5,
+                1
             ],
         ];
     }
 
     /**
      * @dataProvider grade_row_data_provider
-     * @param string $questiontype
-     * @param array $allrowgrades
-     * @return void
      * @throws \coding_exception
      * @throws \dml_exception
      */
     public function test_grade_row(
         string $questiontype,
+        bool $autopass,
         array $allrowgrades
     ):void {
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $autopass, 'qtype_matrix');
         $question = qtype_matrix_test_helper::make_question($questiontype);
         $question->shuffleanswers = false;
         $qa = new \testable_question_attempt($question, 0);
@@ -121,6 +152,7 @@ class difference_test extends advanced_testcase {
             $completerowvariationsgrade = $rowgrades[3];
             $incompletepartiallyrowcorrectgrade = $rowgrades[4];
             $incompleteincorrectrowgrade = $rowgrades[5];
+            $autopassgrade = $rowgrades[6];
             $wrongmessage = 'Wrong for rowindex '.$rowindex;
             $response = qtype_matrix_test_helper::make_correct_answer($question);
             $this->assertEquals($correctrowgrade, $difference->grade_row($question, $rowindex, $response), $wrongmessage);
@@ -139,31 +171,52 @@ class difference_test extends advanced_testcase {
 
             $response = qtype_matrix_test_helper::make_incomplete_wrong_answer($question);
             $this->assertEquals($incompleteincorrectrowgrade, $difference->grade_row($question, $rowindex, $response), $wrongmessage);
+
+            $response = qtype_matrix_test_helper::make_autopass_only_correct_answer($question);
+            $this->assertEquals($autopassgrade, $difference->grade_row($question, $rowindex, $response), $wrongmessage);
         }
     }
 
     public function grade_row_data_provider() {
         // correct, incorrect, one row wrong, complete with row variations, incomplete partially correct, incomplete wrong
         return [
-            'Default question' => ['default', [
-                0 => [1, 0, 0, 1, 1, 0],
-                1 => [1, 0, 1, 1, 1, 0],
-                2 => [1, 0, 1, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0],
+            'No autopass, default question' => ['default', false, [
+                0 => [1, 0, 0, 1, 1, 0, 0.75],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 1],
             ]],
-            'Nondefault question' => ['nondefault', [
-                0 => [1, 0, 0, 1, 1, 0],
-                1 => [1, 0, 1, 1, 1, 0],
-                2 => [1, 0, 1, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0],
+            'Autopass on, default question' => ['default', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1],
+            ]],
+            'No autopass, nondefault question' => ['nondefault', false, [
+                0 => [1, 0, 0, 1, 1, 0, 0.75],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 1],
+            ]],
+            'Autopass on, nondefault question' => ['nondefault', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1],
             ]],
             // TODO: This is correct for the way the difference grading currently works
             //       But I am NOT sure whether the difference grading behaves like it should
-            'multipletwocorrect question' => ['multipletwocorrect', [
-                0 => [1, 0, 0, 1, 1, 0],
-                1 => [1, 0, 1, 0.8888888888888888, 0.8888888888888888, 0],
-                2 => [1, 0, 1, 0.8888888888888888, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0],
+            'No autopass, multipletwocorrect question' => ['multipletwocorrect', false, [
+                0 => [1, 0, 0, 1, 1, 0, 0.8888888888888888],
+                1 => [1, 0, 1, 0.8888888888888888, 0.8888888888888888, 0, 1],
+                2 => [1, 0, 1, 0.8888888888888888, 0, 0, 0.5555555555555556],
+                3 => [1, 0, 1, 0, 0, 0, 1],
+            ]],
+            'Autopass on, multipletwocorrect question' => ['multipletwocorrect', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 0.8888888888888888, 0.8888888888888888, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1],
             ]],
         ];
     }

--- a/tests/local/grading/kany_test.php
+++ b/tests/local/grading/kany_test.php
@@ -20,6 +20,7 @@ defined('MOODLE_INTERNAL') || die();
 
 use advanced_testcase;
 use qtype_matrix\local\grading\kany;
+use qtype_matrix\local\setting;
 use qtype_matrix_test_helper;
 use question_attempt_step;
 use testable_question_attempt;
@@ -34,20 +35,23 @@ class kany_test extends advanced_testcase {
 
     /**
      * @dataProvider grade_question_data_provider
-     * @return void
      * @throws \coding_exception
      * @throws \dml_exception
      */
     public function test_grade_question(
         string $questiontype,
+        bool   $autopass,
         float  $correctgrade,
         float  $incorrectgrade,
         float  $onerowwronggrade,
         float  $completevariationsgrade,
         float  $incompletepartiallycorrectgrade,
         float  $incompleteincorrectgrade,
-        float  $kanygrade
+        float  $kanygrade,
+        float  $autopassgrade
     ):void {
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $autopass, 'qtype_matrix');
         $question = qtype_matrix_test_helper::make_question($questiontype);
         $question->shuffleanswers = false;
         $qa = new testable_question_attempt($question, 0);
@@ -77,6 +81,9 @@ class kany_test extends advanced_testcase {
 
         $response = qtype_matrix_test_helper::make_kany_answer($question);
         $this->assertEquals($kanygrade, $kany->grade_question($question, [4,5,6,7], $response));
+
+        $response = qtype_matrix_test_helper::make_autopass_only_correct_answer($question);
+        $this->assertEquals($autopassgrade, $kany->grade_question($question, [4,5,6,7], $response));
     }
 
     public function grade_question_data_provider():array {
@@ -84,24 +91,38 @@ class kany_test extends advanced_testcase {
         // complete with variations, incomplete partially correct, incomplete wrong,
         // kany specific answer
         return [
-            'Default question' => ['default', 1, 0, 0.5, 0, 0, 0, 0],
-            'Nondefault question' => ['nondefault', 1, 0, 0.5, 0, 0, 0, 0],
-            'multipletwocorrect question' => ['multipletwocorrect', 1, 0, 0.5, 0, 0, 0, 0],
+            'No autopass, default question' => [
+                'default',
+                false,
+                1, // all rows r
+                0, // all rows w
+                0.5, // first row w
+                0, // d+n: 1+2 c, 3+4 w --- m: 1 cc, 2 cw, 3 cx, 4 xw
+                0, // d+n: 1+2 c, 3+4 x --- m: 1 c, 2 cw, 3 x, 4 x
+                0, // 1+2 w, 3+4 x
+                0, // d: cwwx --- n: 1c 2wc 3cw 4w --- m: 1c 2cw 3 cw 4 xc
+                0 // 1+3 w 2+4 c
+            ],
+            'Autopass on, default question' => ['default', true, 1, 0, 1, 0.5, 0.5, 0, 0, 1],
+            'No autopass, nondefault question' => ['nondefault', false, 1, 0, 0.5, 0, 0, 0, 0, 0],
+            'Autopass on, nondefault question' => ['nondefault', true, 1, 0, 1, 0.5, 0.5, 0, 0, 1],
+            'No autopass, multipletwocorrect question' => ['multipletwocorrect', false, 1, 0, 0.5, 0, 0, 0, 0, 0],
+            'Autopass on, multipletwocorrect question' => ['multipletwocorrect', true, 1, 0, 1, 0, 0, 0, 0.5, 1],
         ];
     }
 
     /**
      * @dataProvider grade_row_data_provider
-     * @param string $questiontype
-     * @param array $allrowgrades
-     * @return void
      * @throws \coding_exception
      * @throws \dml_exception
      */
     public function test_grade_row(
         string $questiontype,
+        bool $autopass,
         array $allrowgrades
     ):void {
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $autopass, 'qtype_matrix');
         $question = qtype_matrix_test_helper::make_question($questiontype);
         $question->shuffleanswers = false;
         $qa = new \testable_question_attempt($question, 0);
@@ -121,6 +142,7 @@ class kany_test extends advanced_testcase {
             $incompletepartiallyrowcorrectgrade = $rowgrades[4];
             $incompleteincorrectrowgrade = $rowgrades[5];
             $kanygrade = $rowgrades[6];
+            $autopassgrade = $rowgrades[7];
 
             $wrongmessage = 'Wrong for rowindex '.$rowindex;
             $response = qtype_matrix_test_helper::make_correct_answer($question);
@@ -143,6 +165,9 @@ class kany_test extends advanced_testcase {
 
             $response = qtype_matrix_test_helper::make_kany_answer($question);
             $this->assertEquals($kanygrade, $kany->grade_row($question, $rowindex, $response), $wrongmessage);
+
+            $response = qtype_matrix_test_helper::make_autopass_only_correct_answer($question);
+            $this->assertEquals($autopassgrade, $kany->grade_row($question, $rowindex, $response), $wrongmessage);
         }
     }
 
@@ -151,23 +176,41 @@ class kany_test extends advanced_testcase {
         // complete with row variations, incomplete partially correct, incomplete wrong,
         // kany specific answer
         return [
-            'Default question' => ['default', [
-                0 => [1, 0, 0, 1, 1, 0, 1],
-                1 => [1, 0, 1, 1, 1, 0, 0],
-                2 => [1, 0, 1, 0, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0, 0],
+            'No autopass, default question' => ['default', false, [
+                0 => [1, 0, 0, 1, 1, 0, 1, 0],
+                1 => [1, 0, 1, 1, 1, 0, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 0, 1],
             ]],
-            'Nondefault question' => ['nondefault', [
-                0 => [1, 0, 0, 1, 1, 0, 1],
-                1 => [1, 0, 1, 1, 1, 0, 0],
-                2 => [1, 0, 1, 0, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0, 0],
+            'Autopass on, default question' => ['default', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 1, 1, 0, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 0, 1],
             ]],
-            'multipletwocorrect question' => ['multipletwocorrect', [
-                0 => [1, 0, 0, 1, 1, 0, 1],
-                1 => [1, 0, 1, 0, 0, 0, 0],
-                2 => [1, 0, 1, 1, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0, 1],
+            'No autopass, nondefault question' => ['nondefault', false, [
+                0 => [1, 0, 0, 1, 1, 0, 1, 0],
+                1 => [1, 0, 1, 1, 1, 0, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 0, 1],
+            ]],
+            'Autopass on, nondefault question' => ['nondefault', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 1, 1, 0, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 0, 1],
+            ]],
+            'No autopass, multipletwocorrect question' => ['multipletwocorrect', false, [
+                0 => [1, 0, 0, 1, 1, 0, 1, 0],
+                1 => [1, 0, 1, 0, 0, 0, 0, 1],
+                2 => [1, 0, 1, 1, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 1, 1],
+            ]],
+            'Autopass on, multipletwocorrect question' => ['multipletwocorrect', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 0, 0, 0, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1, 1],
             ]],
         ];
     }

--- a/tests/local/grading/kprime_test.php
+++ b/tests/local/grading/kprime_test.php
@@ -20,6 +20,7 @@ defined('MOODLE_INTERNAL') || die();
 
 use advanced_testcase;
 use qtype_matrix\local\grading\kprime;
+use qtype_matrix\local\setting;
 use qtype_matrix_test_helper;
 use question_attempt_step;
 use testable_question_attempt;
@@ -34,19 +35,22 @@ class kprime_test extends advanced_testcase {
 
     /**
      * @dataProvider grade_question_data_provider
-     * @return void
      * @throws \coding_exception
      * @throws \dml_exception
      */
     public function test_grade_question(
         string $questiontype,
+        bool   $autopass,
         float  $correctgrade,
         float  $incorrectgrade,
         float  $onerowwronggrade,
         float  $completevariationsgrade,
         float  $incompletepartiallycorrectgrade,
-        float  $incompleteincorrectgrade
+        float  $incompleteincorrectgrade,
+        float  $autopassgrade
     ):void {
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $autopass, 'qtype_matrix');
         $question = qtype_matrix_test_helper::make_question($questiontype);
         $question->shuffleanswers = false;
         $qa = new testable_question_attempt($question, 0);
@@ -73,29 +77,35 @@ class kprime_test extends advanced_testcase {
 
         $response = qtype_matrix_test_helper::make_incomplete_wrong_answer($question);
         $this->assertEquals($incompleteincorrectgrade, $kprime->grade_question($question, [4,5,6,7], $response));
+
+        $response = qtype_matrix_test_helper::make_autopass_only_correct_answer($question);
+        $this->assertEquals($autopassgrade, $kprime->grade_question($question, [4,5,6,7], $response));
     }
 
     public function grade_question_data_provider():array {
         // correct, incorrect, one row wrong, complete with variations, incomplete partially correct, incomplete wrong
         return [
-            'Default question' => ['default', 1, 0, 0, 0, 0, 0],
-            'Nondefault question' => ['nondefault', 1, 0, 0, 0, 0, 0],
-            'multipletwocorrect question' => ['multipletwocorrect', 1, 0, 0, 0, 0, 0],
+            'No autopass, default question' => ['default', false, 1, 0, 0, 0, 0, 0, 0],
+            'Autopass on, default question' => ['default', true, 1, 0, 1, 0, 0, 0, 1],
+            'No autopass, nondefault question' => ['nondefault', false, 1, 0, 0, 0, 0, 0, 0],
+            'Autopass on, nondefault question' => ['nondefault', true, 1, 0, 1, 0, 0, 0, 1],
+            'No autopass, multipletwocorrect question' => ['multipletwocorrect', false, 1, 0, 0, 0, 0, 0, 0],
+            'Autopass on, multipletwocorrect question' => ['multipletwocorrect', true, 1, 0, 1, 0, 0, 0, 1],
         ];
     }
 
     /**
      * @dataProvider grade_row_data_provider
-     * @param string $questiontype
-     * @param array $allrowgrades
-     * @return void
      * @throws \coding_exception
      * @throws \dml_exception
      */
     public function test_grade_row(
         string $questiontype,
+        bool $autopass,
         array $allrowgrades
     ):void {
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $autopass, 'qtype_matrix');
         $question = qtype_matrix_test_helper::make_question($questiontype);
         $question->shuffleanswers = false;
         $qa = new \testable_question_attempt($question, 0);
@@ -114,6 +124,7 @@ class kprime_test extends advanced_testcase {
             $completerowvariationsgrade = $rowgrades[3];
             $incompletepartiallyrowcorrectgrade = $rowgrades[4];
             $incompleteincorrectrowgrade = $rowgrades[5];
+            $autopassgrade = $rowgrades[6];
 
             $wrongmessage = 'Wrong for rowindex '.$rowindex;
             $response = qtype_matrix_test_helper::make_correct_answer($question);
@@ -133,29 +144,50 @@ class kprime_test extends advanced_testcase {
 
             $response = qtype_matrix_test_helper::make_incomplete_wrong_answer($question);
             $this->assertEquals($incompleteincorrectrowgrade, $kprime->grade_row($question, $rowindex, $response), $wrongmessage);
+
+            $response = qtype_matrix_test_helper::make_autopass_only_correct_answer($question);
+            $this->assertEquals($autopassgrade, $kprime->grade_row($question, $rowindex, $response), $wrongmessage);
         }
     }
 
     public function grade_row_data_provider() {
         // correct, incorrect, one row wrong, complete with row variations, incomplete partially correct, incomplete wrong
         return [
-            'Default question' => ['default', [
-                0 => [1, 0, 0, 1, 1, 0],
-                1 => [1, 0, 1, 1, 1, 0],
-                2 => [1, 0, 1, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0],
+            'No autopass, default question' => ['default', false, [
+                0 => [1, 0, 0, 1, 1, 0, 0],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 1],
             ]],
-            'Nondefault question' => ['nondefault', [
-                0 => [1, 0, 0, 1, 1, 0],
-                1 => [1, 0, 1, 1, 1, 0],
-                2 => [1, 0, 1, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0],
+            'Autopass on, default question' => ['default', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1],
             ]],
-            'multipletwocorrect question' => ['multipletwocorrect', [
-                0 => [1, 0, 0, 1, 1, 0],
-                1 => [1, 0, 1, 0, 0, 0],
-                2 => [1, 0, 1, 0, 0, 0],
-                3 => [1, 0, 1, 0, 0, 0],
+            'No autopass, nondefault question' => ['nondefault', false, [
+                0 => [1, 0, 0, 1, 1, 0, 0],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 1],
+            ]],
+            'Autopass on, nondefault question' => ['nondefault', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 1, 1, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1],
+            ]],
+            'No autopass, multipletwocorrect question' => ['multipletwocorrect', false, [
+                0 => [1, 0, 0, 1, 1, 0, 0],
+                1 => [1, 0, 1, 0, 0, 0, 1],
+                2 => [1, 0, 1, 0, 0, 0, 0],
+                3 => [1, 0, 1, 0, 0, 0, 1],
+            ]],
+            'Autopass on, multipletwocorrect question' => ['multipletwocorrect', true, [
+                0 => [1, 1, 1, 1, 1, 1, 1],
+                1 => [1, 0, 1, 0, 0, 0, 1],
+                2 => [1, 1, 1, 1, 1, 1, 1],
+                3 => [1, 0, 1, 0, 0, 0, 1],
             ]],
         ];
     }

--- a/tests/output/formulation_and_controls_test.php
+++ b/tests/output/formulation_and_controls_test.php
@@ -18,6 +18,7 @@ namespace qtype_matrix\output;
 
 defined('MOODLE_INTERNAL') || die();
 
+use qtype_matrix\local\setting;
 use qtype_matrix_test_helper;
 use advanced_testcase;
 use question_display_options;
@@ -34,13 +35,27 @@ class formulation_and_controls_test extends advanced_testcase {
 
     /**
      * This is more like a test whether this function will function at all for now.
-     * @return void
+     * @dataProvider export_for_template_data_provider
      * @throws \coding_exception
      * @throws \dml_exception
      */
-    public function test_export_for_template():void {
+    public function test_export_for_template(
+        bool $allowautopass,
+        bool $questionhasautopass
+    ): void {
         global $PAGE;
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $allowautopass, 'qtype_matrix');
+        // Prepare the question.
         $question = qtype_matrix_test_helper::make_question('default');
+        // Shuffling only makes it harder to test.
+        $question->shuffleanswers = false;
+        if (!$questionhasautopass) {
+            foreach ($question->rows as $row) {
+                $row->autopass = false;
+            }
+        }
+        // Simulate the start of an attempt.
         $qa = new testable_question_attempt($question, 0);
         $stepwithresponse = new question_attempt_step();
         $qa->add_step($stepwithresponse);
@@ -48,28 +63,37 @@ class formulation_and_controls_test extends advanced_testcase {
 
         $options = new question_display_options();
         $options->feedback = question_display_options::VISIBLE;
-        // simulate the start of an attempt
-        $options->correctness = question_display_options::HIDDEN;
         $options->numpartscorrect = question_display_options::VISIBLE;
         $options->generalfeedback = question_display_options::VISIBLE;
         $options->rightanswer = question_display_options::VISIBLE;
         $options->manualcomment = question_display_options::VISIBLE;
         $options->history = question_display_options::VISIBLE;
+        // At the start we don't display any correctness feedback.
+        $options->correctness = question_display_options::HIDDEN;
 
         $displayquestion = new formulation_and_controls($qa, $options);
         $renderer = $PAGE->get_renderer('qtype_matrix');
         $context = $displayquestion->export_for_template($renderer);
         $this->assertNotEquals([], $context);
         $this->assertEquals($question->usedndui, $context['usedndui']);
+        $this->assertEquals($questionhasautopass, $context['hasautopassrows']);
         foreach ($context['rows'] as $rowcontext) {
             $this->assertFalse(isset($rowcontext['feedback']));
         }
+        // At the start of the attempt no answer feedback should be shown regardless of autopassing.
+        $this->ensure_autopass_rowcssclasses(false, $context['rows'][0]);
+        $this->ensure_autopass_rowcssclasses(false, $context['rows'][1]);
+        $this->ensure_autopass_rowcssclasses(false, $context['rows'][2]);
+        $this->ensure_autopass_rowcssclasses(false, $context['rows'][3], true);
+        $this->assertEquals(false, $context['rows'][0]['autopassrow']);
+        $this->assertEquals(false, $context['rows'][1]['autopassrow']);
+        $this->assertEquals(false, $context['rows'][2]['autopassrow']);
+        $this->assertEquals(false, $context['rows'][3]['autopassrow']);
         // No response means only show the icons for correct cells.
         $this->assertFalse(isset($context['rows'][0]['cells'][0]['feedback']));
         $this->assertFalse(isset($context['rows'][0]['cells'][1]['feedback']));
 
-        // Simulate a partial answer
-        $question = qtype_matrix_test_helper::make_question('default');
+        // Now simulate an attempt with a step with a partial answer.
         $qa = new testable_question_attempt($question, 0);
         $stepwithresponse = new question_attempt_step([
             'row0col1' => true,
@@ -78,14 +102,26 @@ class formulation_and_controls_test extends advanced_testcase {
         ]);
         $qa->add_step($stepwithresponse);
         $question->start_attempt($stepwithresponse, 1);
-        // Turn on feedback now.
+        // Turn on feedback for the partial answer.
         $options->correctness = question_display_options::VISIBLE;
+
         $displayquestion = new formulation_and_controls($qa, $options);
+        $renderer = $PAGE->get_renderer('qtype_matrix');
         $context = $displayquestion->export_for_template($renderer);
 
         foreach ($context['rows'] as $rowcontext) {
             $this->assertNotEmpty($rowcontext['feedback']);
         }
+
+        $this->ensure_autopass_rowcssclasses($allowautopass && $questionhasautopass, $context['rows'][0]);
+        $this->ensure_autopass_rowcssclasses(false, $context['rows'][1]);
+        $this->ensure_autopass_rowcssclasses($allowautopass && $questionhasautopass, $context['rows'][2]);
+        $this->ensure_autopass_rowcssclasses(false, $context['rows'][3], true);
+        $this->assertEquals($allowautopass && $questionhasautopass, $context['rows'][0]['autopassrow']);
+        $this->assertEquals(false, $context['rows'][1]['autopassrow']);
+        $this->assertEquals($allowautopass && $questionhasautopass, $context['rows'][2]['autopassrow']);
+        $this->assertEquals(false, $context['rows'][3]['autopassrow']);
+
         // Not checked and not correct, so no feedback.
         $this->assertFalse($context['rows'][0]['cells'][0]['ischecked']);
         $this->assertFalse(isset($context['rows'][0]['cells'][0]['feedbackimage']));
@@ -115,4 +151,26 @@ class formulation_and_controls_test extends advanced_testcase {
         $this->assertTrue(isset($context['rows'][2]['cells'][2]['feedbackimage']));
     }
 
+    private function ensure_autopass_rowcssclasses(bool $should, array $rowcontext, bool $othercssclasses = false) {
+        if ($should) {
+            $this->assertStringContainsString('autopassrow', $rowcontext['rowcssclasses']);
+        } else {
+            if ($othercssclasses) {
+                $this->assertStringNotContainsString('autopassrow', $rowcontext['rowcssclasses']);
+            } else {
+                $this->assertArrayNotHasKey('rowcssclasses', $rowcontext);
+            }
+        }
+    }
+
+    public function export_for_template_data_provider() {
+        return [
+            'No autopass, question without autopass' => [false, false],
+            'No autopass, question with autopass' => [false, true],
+            'Autopass on, question without autopass' => [true, false],
+            'Autopass on, question with autopass' => [true, true],
+        ];
+    }
+
 }
+

--- a/tests/qtype_matrix_question_test.php
+++ b/tests/qtype_matrix_question_test.php
@@ -22,6 +22,7 @@ use qtype_matrix\local\grading\difference;
 use qtype_matrix\local\grading\kany;
 use qtype_matrix\local\grading\kprime;
 use qtype_matrix\local\qtype_matrix_grading;
+use qtype_matrix\local\setting;
 use qtype_matrix_question;
 use question_attempt_step;
 use question_classified_response;
@@ -292,9 +293,9 @@ class qtype_matrix_question_test extends advanced_testcase {
     public function test_validate_can_regrade_with_other_version(
         qtype_matrix_question $somequestion,
         qtype_matrix_question $otherquestion,
-        bool $canregrade
+        bool $shouldberegradable
     ):void {
-        if ($canregrade) {
+        if ($shouldberegradable) {
             $this->assertNull($somequestion->validate_can_regrade_with_other_version($otherquestion));
         } else {
             $this->assertNotNull($somequestion->validate_can_regrade_with_other_version($otherquestion));
@@ -307,28 +308,36 @@ class qtype_matrix_question_test extends advanced_testcase {
 
     public function validate_can_regrade_data_provider() {
         $helper = new qtype_matrix_test_helper();
+
         $question = qtype_matrix_test_helper::make_question('default');
+
         $equivalentquestion = qtype_matrix_test_helper::make_question('default');
+
         $morerowsquestion = qtype_matrix_test_helper::make_question('default');
         $morerowsquestion->rows[12] = $helper->generate_matrix_row_or_column(12, true);
+
         $lessrowsquestion = qtype_matrix_test_helper::make_question('default');
         unset($lessrowsquestion->rows[4]);
+
         $morecolsquestion = qtype_matrix_test_helper::make_question('default');
         $morecolsquestion->rows[12] = $helper->generate_matrix_row_or_column(12, false);
+
         $lesscolsquestion = qtype_matrix_test_helper::make_question('default');
         unset($lesscolsquestion->rows[4]);
+
         $multiplesamenranswersquestion = qtype_matrix_test_helper::make_question('nondefault');
-        // $differentnrofanswersquestion = qtype_matrix_test_helper::make_question('multipletwocorrect');
+
+        $differentnrofanswersquestion = qtype_matrix_test_helper::make_question('multipletwocorrect');
+
         return [
             'Same question' => [$question, $question, true],
             'Equivalent question' => [$question, $equivalentquestion, true],
-            'More rows question' => [$question, $morerowsquestion, false],
-            'Less rows question' => [$question, $lessrowsquestion, false],
-            'More columns question' => [$question, $morecolsquestion, false],
-            'Less columns question' => [$question, $lesscolsquestion, false],
-            'Multiple, same nr of answers per row' => [$question, $multiplesamenranswersquestion, true],
-            // FIXME: See function, currently used in a workflow for the same amount of point for all participants
-            // 'Multiple, different nr of right answers per row' => [$question, $differentnrofanswersquestion, false],
+            'Question with more rows' => [$question, $morerowsquestion, false],
+            'Question with less rows' => [$question, $lessrowsquestion, false],
+            'Question with more columns' => [$question, $morecolsquestion, false],
+            'Question with less columns' => [$question, $lesscolsquestion, false],
+            'Changing multiple, but still one correct answer per row' => [$question, $multiplesamenranswersquestion, true],
+            'Changing multiple, more than one correct answer per row' => [$question, $differentnrofanswersquestion, false]
         ];
     }
 
@@ -367,24 +376,30 @@ class qtype_matrix_question_test extends advanced_testcase {
      * @dataProvider grade_response_data_provider
      * @param string $questiontype
      * @param string $grademethod
+     * @param bool $autopass
      * @param question_state $expectedstateforcorrect
      * @param question_state $expectedstateforincorrect
      * @param question_state $expectedstateforonerowwrong
      * @param question_state $expectedstateforcompletewithrowvariations
      * @param question_state $expectedstateforincompletepartiallycorrect
      * @param question_state $expectedstateforincompleteincorrect
+     * @param question_state $expectedstateforautopassonlycorrectanswer
      * @return void
      */
     public function test_grade_response(
         string $questiontype,
         string $grademethod,
+        bool $autopass,
         question_state $expectedstateforcorrect,
         question_state $expectedstateforincorrect,
         question_state $expectedstateforonerowwrong,
         question_state $expectedstateforcompletewithrowvariations,
         question_state $expectedstateforincompletepartiallycorrect,
         question_state $expectedstateforincompleteincorrect,
+        question_state $expectedstateforautopassonlycorrectanswer
     ): void {
+        $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, $autopass, 'qtype_matrix');
         $question = qtype_matrix_test_helper::make_question($questiontype);
         $this->initialize_order($question);
         $question->grademethod = $grademethod;
@@ -412,6 +427,10 @@ class qtype_matrix_question_test extends advanced_testcase {
         $incompletewronganswer = qtype_matrix_test_helper::make_incomplete_wrong_answer($question);
         $state = $question->grade_response($incompletewronganswer)[1];
         $this->assertEquals($expectedstateforincompleteincorrect, $state);
+
+        $autopassonlycorrectanswer = qtype_matrix_test_helper::make_autopass_only_correct_answer($question);
+        $state = $question->grade_response($autopassonlycorrectanswer)[1];
+        $this->assertEquals($expectedstateforautopassonlycorrectanswer, $state);
     }
 
     /**
@@ -425,18 +444,38 @@ class qtype_matrix_question_test extends advanced_testcase {
         $w = question_state::$gradedwrong;
         $p = question_state::$gradedpartial;
         return [
-            'Default question, kprime grading' => ['default', kprime::get_name(), $r, $w, $w, $w, $w, $w],
-            'Default question, kany grading' => ['default', kany::get_name(), $r, $w, $p, $w, $w, $w],
-            'Default question, all grading' => ['default', all::get_name(), $r, $w, $p, $p, $p, $w],
-            'Default question, difference grading' => ['default', difference::get_name(), $r, $w, $p, $p, $p, $w],
-            'Nondefault question, kprime grading' => ['nondefault', kprime::get_name(), $r, $w, $w, $w, $w, $w],
-            'Nondefault question, kany grading' => ['nondefault', kany::get_name(), $r, $w, $p, $w, $w, $w],
-            'Nondefault question, all grading' => ['nondefault', all::get_name(), $r, $w, $p, $p, $p, $w],
-            'Nondefault question, difference grading' => ['nondefault', difference::get_name(), $r, $w, $p, $p, $p, $w],
-            'multipletwocorrect question, kprime grading' => ['multipletwocorrect', kprime::get_name(), $r, $w, $w, $w, $w, $w],
-            'multipletwocorrect question, kany grading' => ['multipletwocorrect', kany::get_name(), $r, $w, $p, $w, $w, $w],
-            'multipletwocorrect question, all grading' => ['multipletwocorrect', all::get_name(), $r, $w, $p, $p, $p, $w],
-            'multipletwocorrect question, difference grading' => ['multipletwocorrect', difference::get_name(), $r, $w, $p, $p, $p, $w]
+            'No autopass, Default question, kprime grading' => ['default', kprime::get_name(), false, $r, $w, $w, $w, $w, $w, $w],
+            'No autopass, Default question, kany grading' => ['default', kany::get_name(), false, $r, $w, $p, $w, $w, $w, $w],
+            'No autopass, Default question, all grading' => ['default', all::get_name(), false, $r, $w, $p, $p, $p, $w, $p],
+            'No autopass, Default question, difference grading' => ['default', difference::get_name(), false, $r, $w, $p, $p, $p, $w, $p],
+            'No autopass, Nondefault question, kprime grading' => ['nondefault', kprime::get_name(), false, $r, $w, $w, $w, $w, $w, $w],
+            'No autopass, Nondefault question, kany grading' => ['nondefault', kany::get_name(), false, $r, $w, $p, $w, $w, $w, $w],
+            'No autopass, Nondefault question, all grading' => ['nondefault', all::get_name(), false, $r, $w, $p, $p, $p, $w, $p],
+            'No autopass, Nondefault question, difference grading' => ['nondefault', difference::get_name(), false, $r, $w, $p, $p, $p, $w, $p],
+            'No autopass, multipletwocorrect question, kprime grading' => ['multipletwocorrect', kprime::get_name(), false, $r, $w, $w, $w, $w, $w, $w],
+            'No autopass, multipletwocorrect question, kany grading' => ['multipletwocorrect', kany::get_name(), false, $r, $w, $p, $w, $w, $w, $w],
+            'No autopass, multipletwocorrect question, all grading' => ['multipletwocorrect', all::get_name(), false, $r, $w, $p, $p, $p, $w, $p],
+            'No autopass, multipletwocorrect question, difference grading' => ['multipletwocorrect', difference::get_name(), false, $r, $w, $p, $p, $p, $w, $p],
+//            question_state no wrong,
+//        question_state 1-4 wrong,
+//        question_state 1 wrong,
+// 4       question_state default nondefault: 3,4 wrong, multiple: 2+3 hw, 4 wrong
+// 5       question_state default: 3+4 wrong, multiple: 2 hw, 3+4 wrong,
+// 6       question_state 1-4 wrong,
+// 7       question_state 1+3 wrong
+// all: partiell, difference: partiell, kany: eine weniger ist erlaubt, kprime: alle müssen
+            'Autopass on, Default question, kprime grading' => ['default', kprime::get_name(), true, $r, $w, $r, $w, $w, $w, $r],
+            'Autopass on, Default question, kany grading' => ['default', kany::get_name(), true, $r, $w, $r, $p, $p, $w, $r],
+            'Autopass on, Default question, all grading' => ['default', all::get_name(), true, $r, $p, $r, $p, $p, $p, $r],
+            'Autopass on, Default question, difference grading' => ['default', difference::get_name(), true, $r, $p, $r, $p, $p, $p, $r],
+            'Autopass on, Nondefault question, kprime grading' => ['nondefault', kprime::get_name(), true, $r, $w, $r, $w, $w, $w, $r],
+            'Autopass on, Nondefault question, kany grading' => ['nondefault', kany::get_name(), true, $r, $w, $r, $p, $p, $w, $r],
+            'Autopass on, Nondefault question, all grading' => ['nondefault', all::get_name(), true, $r, $p, $r, $p, $p, $p, $r],
+            'Autopass on, Nondefault question, difference grading' => ['nondefault', difference::get_name(), true, $r, $p, $r, $p, $p, $p, $r],
+            'Autopass on, multipletwocorrect question, kprime grading' => ['multipletwocorrect', kprime::get_name(), true, $r, $w, $r, $w, $w, $w, $r],
+            'Autopass on, multipletwocorrect question, kany grading' => ['multipletwocorrect', kany::get_name(), true, $r, $w, $r, $w, $w, $w, $r],
+            'Autopass on, multipletwocorrect question, all grading' => ['multipletwocorrect', all::get_name(), true, $r, $p, $r, $p, $p, $p, $r],
+            'Autopass on, multipletwocorrect question, difference grading' => ['multipletwocorrect', difference::get_name(), true, $r, $p, $r, $p, $p, $p, $r]
         ];
     }
     /**

--- a/tests/qtype_matrix_test.php
+++ b/tests/qtype_matrix_test.php
@@ -16,7 +16,9 @@
 
 namespace qtype_matrix;
 
+use core_question\local\bank\question_version_status;
 use qtype_matrix\local\qtype_matrix_grading;
+use qtype_matrix\local\setting;
 use qtype_matrix_test_helper;
 use qtype_matrix;
 use advanced_testcase;
@@ -24,6 +26,7 @@ use context_course;
 use qformat_xml;
 use question_bank;
 use test_question_maker;
+use stdClass;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -133,6 +136,7 @@ class qtype_matrix_test extends advanced_testcase {
             $this->assertEquals(FORMAT_HTML, $questiondatarow->description['format']);
             $this->assertEquals($matrixrow->feedback, $questiondatarow->feedback['text']);
             $this->assertEquals(FORMAT_HTML, $questiondatarow->feedback['format']);
+            $this->assertEquals($matrixrow->autopass, $questiondatarow->autopass);
         }
         $matrixcols = $DB->get_records('qtype_matrix_cols', ['matrixid' => $matrixoptions->id]);
         $this->assertIsArray($questiondata->options->cols);
@@ -187,6 +191,7 @@ class qtype_matrix_test extends advanced_testcase {
             $this->assertEquals(FORMAT_HTML, $retrievedmatrixrow->description['format']);
             $this->assertEquals($matrixrow->feedback, $retrievedmatrixrow->feedback['text']);
             $this->assertEquals(FORMAT_HTML, $retrievedmatrixrow->feedback['format']);
+            $this->assertEquals($matrixrow->autopass, $retrievedmatrixrow->autopass);
         }
         $matrixcols = $DB->get_records('qtype_matrix_cols', ['matrixid' => $matrixoptions->id]);
         $this->assertIsArray($matrix->cols);
@@ -211,16 +216,23 @@ class qtype_matrix_test extends advanced_testcase {
 
     /**
      * @dataProvider save_question_options_data_provider
-     * @param bool $type What test question type will be used
-     * @param array $expectedmultiple What the question value for multiple should be
-     * @param array $nrweightrecords Expected nr of weight records
+     * @param string $type What test question type will be used
+     * @param bool $triggerautopass - Whether the autopass values should be stored
+     * @param bool $expectedmultiple What the question value for multiple should be
+     * @param int $nrweightrecords Expected nr of weight records
      * @return void
      * @throws \dml_exception
      * @throws \dml_transaction_exception
      */
-    public function test_save_question_options($type, $expectedmultiple, $nrweightrecords):void {
+    public function test_save_question_options(
+        string $type,
+        bool $triggerautopass,
+        bool $expectedmultiple,
+        int $nrweightrecords
+    ):void {
         global $DB;
         $this->resetAfterTest();
+        set_config(setting::SETTING_ALLOW_AUTOPASS, true, 'qtype_matrix');
         $typequestion = qtype_matrix_test_helper::make_question($type);
         $fromform = test_question_maker::get_question_form_data('matrix', $type);
         $this->assertEquals($expectedmultiple, $fromform->multiple);
@@ -229,6 +241,16 @@ class qtype_matrix_test extends advanced_testcase {
         $this->assertEquals(0, $DB->count_records('qtype_matrix_rows'));
         $this->assertEquals(0, $DB->count_records('qtype_matrix_cols'));
         $this->assertEquals(0, $DB->count_records('qtype_matrix_weights'));
+        $this->assertEquals(0, $DB->count_records('question_versions'));
+
+        $fakeversionrecord = new stdClass();
+        $fakeversionrecord->questionbankentryid = 345;
+        $fakeversionrecord->questionid = $fromform->id;
+        $fakeversionrecord->status = question_version_status::QUESTION_STATUS_READY;
+        $fakeversionrecord->version = $triggerautopass ? 2 : 1;
+        $DB->insert_record('question_versions', $fakeversionrecord);
+        $this->assertEquals(1, $DB->count_records('question_versions'));
+
         $errors = $this->qtype->save_question_options($fromform);
         $this->assertIsObject($errors);
         $this->assertFalse((bool) get_object_vars($errors));
@@ -248,6 +270,8 @@ class qtype_matrix_test extends advanced_testcase {
             $this->assertEquals($fromform->rows_shorttext[$rowindex], $matrixrow->shorttext);
             $this->assertEquals($fromform->rows_description[$rowindex]['text'], $matrixrow->description);
             $this->assertEquals($fromform->rows_feedback[$rowindex]['text'], $matrixrow->feedback);
+            $expectedautopassvalue = $triggerautopass ? $fromform->rows_autopass[$rowindex] : false;
+            $this->assertEquals($expectedautopassvalue, $matrixrow->autopass);
             $rowindex++;
         }
 
@@ -302,9 +326,12 @@ class qtype_matrix_test extends advanced_testcase {
      */
     public function save_question_options_data_provider():array {
         return [
-            'Default question' => ['default', false, 4],
-            'Nondefault question' => ['nondefault', true, 4],
-            'Multiple, two correct question' => ['multipletwocorrect', true, 8],
+            'First version, default question' => ['default', false, false, 4],
+            'Later version, default question' => ['default', true, false, 4],
+            'First version, nondefault question' => ['nondefault', false, true, 4],
+            'Later version, nondefault question' => ['nondefault', true, true, 4],
+            'First version, multiple, two correct question' => ['multipletwocorrect', false, true, 8],
+            'Later version, multiple, two correct question' => ['multipletwocorrect', true, true, 8],
         ];
     }
 
@@ -516,6 +543,18 @@ class qtype_matrix_test extends advanced_testcase {
         $this->assertEquals(qtype_matrix::DEFAULT_MULTIPLE, $fromform->multiple);
         $this->assertEquals(qtype_matrix::DEFAULT_USEDNDUI, $fromform->usedndui);
         $this->assertEquals(qtype_matrix::DEFAULT_SHUFFLEANSWERS, $fromform->shuffleanswers);
+    }
+
+    public function test_import_from_xml_autopass_question():void {
+        $xmlcontent = implode('', file(__DIR__ . '/fixtures/autopass_question_to_import.xml'));
+        $xml = xmlize($xmlcontent, 0, 'UTF-8', true);
+        $qformat = new qformat_xml();
+        $fromform = new \stdClass();
+        $fromform = $this->qtype->import_from_xml($xml['question'], $fromform, $qformat);
+        $this->assertEquals(0, $fromform->rows_autopass[0]);
+        $this->assertEquals(0, $fromform->rows_autopass[1]);
+        $this->assertEquals(0, $fromform->rows_autopass[2]);
+        $this->assertEquals(0, $fromform->rows_autopass[3]);
     }
 
     // FIXME: There should probably a question with invalid values for everything

--- a/tests/restore_qtype_matrix_plugin_test.php
+++ b/tests/restore_qtype_matrix_plugin_test.php
@@ -30,9 +30,6 @@ class restore_qtype_matrix_plugin_test extends advanced_testcase {
     ):void {
         global $DB;
         $this->resetAfterTest();
-        $backupquestionid = 123;
-        $createdquestionid = 234;
-
         $mockedrestore = $this
             ->getMockBuilder(restore_qtype_matrix_plugin::class)
             ->setConstructorArgs([
@@ -48,18 +45,23 @@ class restore_qtype_matrix_plugin_test extends advanced_testcase {
                 'set_mapping'
             ])
             ->getMock();
+        // Testing this method breaks into the restore workflow.
+        // We can't first create the question or map the restored question to an existing one.
+        // But we can tell the function whether one or the other case happened.
         $mockedrestore->method('is_question_created')->willReturn($questioncreated);
+        $createdquestionid = 234;
         $mockedrestore->method('get_new_parentid')->willReturn($createdquestionid);
 
-        $backupdata = [
-            'id' => $backupquestionid,
+        $matrixoptionsbackup = [
+            'id' => 123,
             'grademethod' => $grademethod,
             'multiple' => $multiple,
             'shuffleanswers' => $shuffleanswers,
             'usedndui' => $usedndui
         ];
         $this->assertEquals(0, $DB->count_records('qtype_matrix'));
-        $mockedrestore->process_matrix($backupdata);
+        $mockedrestore->process_matrix($matrixoptionsbackup);
+        // If we created a new question we also need a new matrix record (1-on-1 relationship).
         $nrmatrixrecords = $questioncreated ? 1 : 0;
         $this->assertEquals($nrmatrixrecords, $DB->count_records('qtype_matrix'));
         if ($questioncreated) {
@@ -88,22 +90,98 @@ class restore_qtype_matrix_plugin_test extends advanced_testcase {
     }
 
     /**
-     * @dataProvider process_col_data_provider
+     * @dataProvider process_row_data_provider
      * @param bool $questioncreated
      * @return void
      * @throws dml_exception
      */
-    public function test_process_col(
-        string $backupshorttext,
-        string $backupdescription,
+    public function test_process_row(
         bool $questioncreated,
-        bool $exceptionexpected
+        ?int $createdmatrixid,
+        bool $expectexception,
+        bool $autopass,
+        bool $firstversion
     ): void {
-        global $DB;
         $this->resetAfterTest();
-        $backupcolid = 456;
-        $backupmatrixid = 123;
-        $createdormappedmatrixid = 234;
+        $rowbackup = [
+            'id' => 456,
+            'matrixid' => 123,
+            'shorttext' => 'BackupShorttext',
+            'description' => 'BackupDescription',
+            'autopass' => $autopass ? '1' : '0'
+        ];
+
+        $this->process_dim(
+            true,
+            $rowbackup,
+            $questioncreated,
+            $createdmatrixid,
+            $expectexception,
+            $firstversion
+        );
+    }
+
+    public function process_row_data_provider() {
+        return [
+            'Good data, question created, no autopass, v1' => [true, 234, false, false, true],
+            'Good data, question created, no autopass, v2' => [true, 234, false, false, false],
+            'Good data, question created, with autopass, v1' => [true, 234, false, true, true],
+            'Good data, question created, with autopass, v2' => [true, 234, false, true, false],
+            'Good data, question mapped, no autopass, v1' => [false, null, false, false, true],
+            'Good data, question mapped, no autopass, v2' => [false, null, false, false, false],
+            'Good data, question mapped, with autopass, v1' => [false, null, false, true, true],
+            'Good data, question mapped, with autopass, v2' => [false, null, false, true, false],
+            'Question created but no matrix found' => [true, null, true, false, true]
+        ];
+    }
+
+    /**
+     * @dataProvider process_col_data_provider
+     * @param bool $questioncreated
+     * @param int|null $createdmatrixid
+     * @param bool $expectexception
+     * @return void
+     * @throws dml_exception
+     */
+    public function test_process_col(
+        bool $questioncreated,
+        ?int $createdmatrixid,
+        bool $expectexception
+    ): void {
+        $this->resetAfterTest();
+        $colbackup = [
+            'id' => 456,
+            'matrixid' => 123,
+            'shorttext' => 'BackupShorttext',
+            'description' => 'BackupDescription'
+        ];
+        $this->process_dim(
+            false,
+            $colbackup,
+            $questioncreated,
+            $createdmatrixid,
+            $expectexception,
+            true
+        );
+    }
+
+    public function process_col_data_provider() {
+        return [
+            'Good data, question created' => [true, 234, false],
+            'Good data, question mapped' => [false, null, false],
+            'Question created but no matrix created' => [true, null, true]
+        ];
+    }
+
+    private function process_dim(
+        bool $isrow,
+        array $dimbackup,
+        bool $questioncreated,
+        ?int $createdmatrixid,
+        bool $expectexception,
+        bool $firstversion
+    ) {
+        global $DB;
         $mockedrestore = $this
             ->getMockBuilder(restore_qtype_matrix_plugin::class)
             ->setConstructorArgs([
@@ -115,48 +193,52 @@ class restore_qtype_matrix_plugin_test extends advanced_testcase {
                     null
                 )])->onlyMethods([
                 'is_question_created',
-                'get_old_parentid',
                 'get_new_parentid',
+                'created_as_first_version',
                 'set_mapping'
             ])
             ->getMock();
         $mockedrestore->method('is_question_created')->willReturn($questioncreated);
-        $mockedrestore->method('get_old_parentid')->willReturn($backupmatrixid);
-        $mockedrestore->method('get_new_parentid')->willReturn($createdormappedmatrixid);
-        $backupdata = [
-            'id' => $backupcolid,
-            'matrixid' => $backupmatrixid,
-            'shorttext' => $backupshorttext,
-            'description' => $backupdescription
-        ];
-        $this->assertEquals(0, $DB->count_records('qtype_matrix_cols'));
-        if ($exceptionexpected) {
-            $this->expectExceptionMessageMatches('/Failed to find an answer matching/');
+        $mockedrestore->method('get_new_parentid')->willReturn($createdmatrixid);
+        $mockedrestore->method('created_as_first_version')->willReturn($firstversion);
+        $dimtable = $isrow ? 'qtype_matrix_rows' : 'qtype_matrix_cols';
+        $this->assertEquals(0, $DB->count_records($dimtable));
+        if ($expectexception) {
+            $this->expectExceptionMessageMatches(
+                '/' . restore_qtype_matrix_plugin::ERROR_INCONSISTENT_BEHAVIOUR . '/'
+            );
         }
-        $mockedrestore->process_col($backupdata);
-        $expectedcolrecords = $questioncreated ? 1 : 0;
-        $this->assertEquals($expectedcolrecords, $DB->count_records('qtype_matrix_cols'));
+        if ($isrow) {
+            $mockedrestore->process_row($dimbackup);
+        } else {
+            $mockedrestore->process_col($dimbackup);
+        }
+        $expecteddimrecords = $questioncreated ? 1 : 0;
+        $this->assertEquals($expecteddimrecords, $DB->count_records($dimtable));
         if ($questioncreated) {
-            $createdcol = $DB->get_record('qtype_matrix_cols', ['matrixid' => $createdormappedmatrixid]);
-            $this->assertNotNull($createdcol);
-            $this->assertEquals($createdormappedmatrixid, $createdcol->matrixid);
-            $this->assertEquals($backupshorttext, $createdcol->shorttext);
-            $this->assertEquals($backupdescription, $createdcol->description);
+            $createddim = $DB->get_record($dimtable, ['matrixid' => $createdmatrixid]);
+            $this->assertNotNull($createddim);
+            $this->assertEquals($createdmatrixid, $createddim->matrixid);
+            $this->assertEquals($dimbackup['shorttext'], $createddim->shorttext);
+            $this->assertEquals($dimbackup['description'], $createddim->description);
+            if ($isrow) {
+                $expectedautopass = (int) ($firstversion ? 0 : $dimbackup['autopass']);
+                $this->assertEquals($expectedautopass, $createddim->autopass);
+            }
         }
-        // FIXME: Missing that the question was mapped and the matching column can be found
     }
 
-    public function process_col_data_provider() {
-        return [
-            'Good data, question created' => ['BShorttext', 'BDescription', true, false],
-            // FIXME: This should be tested once we prevent rows/columns having the same shorttext
-            // 'Good data, question mapped, matching column' => ['BShorttext', 'BDescription', false, false],
-            // FIXME: This test is probably useless, should never happen if questiondata hash generation is good
-            'Good data, question mapped, no matching column' => ['BShorttext', 'BDescription', false, true]
-        ];
-    }
-
-    public function test_process_weight():void {
+    /**
+     * @dataProvider process_weight_data_provider
+     * @param bool $questioncreated
+     * @param bool $expectexception
+     * @return void
+     * @throws dml_exception
+     */
+    public function test_process_weight(
+        bool $questioncreated,
+        bool $produceexception
+    ):void {
         global $DB;
         $this->resetAfterTest();
         $mockedrestore = $this
@@ -169,36 +251,53 @@ class restore_qtype_matrix_plugin_test extends advanced_testcase {
                     'filename',
                     null
                 )])->onlyMethods([
+                'is_question_created',
                 'get_mappingid',
                 'set_mapping'
             ])
             ->getMock();
-        $backupweightid = 345;
-        $backuprowid = 123;
-        $backupcolid = 234;
-        $mappedrowid = 456;
-        $mappedcolid = 567;
-        $get_mappingid_map = [
-            ['row', $backuprowid, false, $mappedrowid],
-            ['col', $backupcolid, false, $mappedcolid],
-        ];
-        $mockedrestore->method('get_mappingid')->willReturnMap($get_mappingid_map);
-        $backupdata = [
-            'id' => $backupweightid,
-            'rowid' => $backuprowid,
-            'colid' => $backupcolid,
+        $mockedrestore->method('is_question_created')->willReturn($questioncreated);
+        $weightbackup = [
+            'id' => 345,
+            'rowid' => 123,
+            'colid' => 234,
             'weight' => 1
         ];
+
+        $createdrowid = (!$questioncreated || $produceexception) ? 0 : 456;
+        $createdcolid = (!$questioncreated || $produceexception) ? 0 : 567;
+        $get_mappingid_map = [
+            ['row', $weightbackup['rowid'], false, $createdrowid],
+            ['col', $weightbackup['colid'], false, $createdcolid],
+        ];
+        $mockedrestore->method('get_mappingid')->willReturnMap($get_mappingid_map);
+
         $this->assertEquals(0, $DB->count_records('qtype_matrix_weights'));
-        $mockedrestore->process_weight($backupdata);
-        $this->assertEquals(1, $DB->count_records('qtype_matrix_weights'));
-        $createdweightrecord = $DB->get_record('qtype_matrix_weights', ['colid' => $mappedcolid]);
-        $this->assertNotNull($createdweightrecord);
-        $this->assertNotEquals($backuprowid, $createdweightrecord->rowid);
-        $this->assertEquals($mappedrowid, $createdweightrecord->rowid);
-        $this->assertNotEquals($backupcolid, $createdweightrecord->colid);
-        $this->assertEquals($mappedcolid, $createdweightrecord->colid);
-        $this->assertEquals(1, $createdweightrecord->weight);
+        if ($produceexception) {
+            $this->expectExceptionMessageMatches(
+                '/' . restore_qtype_matrix_plugin::ERROR_INCONSISTENT_BEHAVIOUR . '/'
+            );
+        }
+        $mockedrestore->process_weight($weightbackup);
+        $weightscreated = $questioncreated ? 1 : 0;
+        $this->assertEquals($weightscreated, $DB->count_records('qtype_matrix_weights'));
+        if ($weightscreated) {
+            $createdweightrecord = $DB->get_record('qtype_matrix_weights', ['colid' => $createdcolid]);
+            $this->assertNotNull($createdweightrecord);
+            $this->assertNotEquals($weightbackup['rowid'], $createdweightrecord->rowid);
+            $this->assertEquals($createdrowid, $createdweightrecord->rowid);
+            $this->assertNotEquals($weightbackup['colid'], $createdweightrecord->colid);
+            $this->assertEquals($createdcolid, $createdweightrecord->colid);
+            $this->assertEquals($weightbackup['weight'], $createdweightrecord->weight);
+        }
+    }
+
+    public function process_weight_data_provider() {
+        return [
+            'question created, no exception' => [true, false],
+            'question created, exception' => [true, true],
+            'question mapped, no exception' => [false, false]
+        ];
     }
 
     public function test_recode_legacy_state_answer():void {
@@ -411,12 +510,14 @@ class restore_qtype_matrix_plugin_test extends advanced_testcase {
         $matrix['rows']['row'][0] = [
             'id' => '123',
             'description' => 'backuprowdesc',
-            'feedback' => 'backuprowfeedback'
+            'feedback' => 'backuprowfeedback',
+            'autopass' => '1'
         ];
         $matrix['rows']['row'][1] = [
             'id' => '124',
             'description' => 'backuprowdesc124',
-            'feedback' => 'backuprowfeedback124'
+            'feedback' => 'backuprowfeedback124',
+            'autopass' => '0'
         ];
         $matrix['cols']['col'][0] = [
             'id' => '234',
@@ -448,7 +549,8 @@ class restore_qtype_matrix_plugin_test extends advanced_testcase {
             'feedback' => [
                 'text' => 'backuprowfeedback',
                 'format' => FORMAT_HTML
-            ]
+            ],
+            'autopass' => true
         ];
         $rows[124] = (object) [
             'id' => 124,
@@ -460,7 +562,8 @@ class restore_qtype_matrix_plugin_test extends advanced_testcase {
             'feedback' => [
                 'text' => 'backuprowfeedback124',
                 'format' => FORMAT_HTML
-            ]
+            ],
+            'autopass' => false
         ];
         $options->cols = [];
         $cols = &$options->cols;

--- a/version.php
+++ b/version.php
@@ -17,7 +17,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_matrix';
-$plugin->version = 2025093004;
+$plugin->version = 2025093005;
 $plugin->requires = 2024100700; // Moodle 4.5
 $plugin->release = '3.9 for Moodle 4.5-5.0 (Build: 2025093000)';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
I've cherry picked the autopass commits into a new branch because the old branch contained a big swath of old code that was already rebased and this was easier than rebasing the old branch.

So this should now contain only the autopass changes and probably solves #77.

What we probably need to do now:
- My people are tasked with the english and german texts for the strings
- Someone has to look at the layout/colors/accessibility when a row is shown as autopassed (The task has been mentioned to my people)
- As of now it is still possible to rename the new stuff (i.e. "autopass" or some such is not set in stone)
- You could take a general look at the code to check for bugs or potential problems
- There are still CI errors that have to be looked at

I also have to talk with the exam people about all this again...So this gets to be marked as a draft at first again...